### PR TITLE
Implement partial support for `box-shadow` and add support for clipping out (rectangle subtraction) to the clipper.

### DIFF
--- a/res/box-shadow-corner.fs.glsl
+++ b/res/box-shadow-corner.fs.glsl
@@ -1,0 +1,25 @@
+#version 110
+
+#ifdef GL_ES
+    precision mediump float;
+#endif
+
+uniform sampler2D sDiffuse;
+
+uniform vec4 uPosition;
+uniform float uBlurRadius;
+uniform float uArcRadius;
+
+varying vec4 vColor;
+varying vec2 vPosition;
+
+void main(void)
+{
+    vec2 lPosition = vPosition - uPosition.xy;
+    vec2 lArcCenter = uPosition.zw;
+    float lDistance = distance(lPosition, vec2(lArcCenter));
+    float lValue = clamp(lDistance, uArcRadius - uBlurRadius, uArcRadius + uBlurRadius);
+    lValue = ((lValue - uArcRadius) / uBlurRadius + 1.0) / 2.0;
+    gl_FragColor = vec4(1.0 - lValue);
+}
+

--- a/res/box-shadow-corner.vs.glsl
+++ b/res/box-shadow-corner.vs.glsl
@@ -1,0 +1,16 @@
+#version 110
+
+attribute vec3 aPosition;
+attribute vec4 aColor;
+
+uniform mat4 uTransform;
+
+varying vec4 vColor;
+varying vec2 vPosition;
+
+void main(void)
+{
+	vColor = aColor;
+	vPosition = aPosition.xy;
+    gl_Position = uTransform * vec4(aPosition, 1.0);
+}

--- a/src/device.rs
+++ b/src/device.rs
@@ -52,6 +52,7 @@ impl FBOId {
     fn bind(&self) {
         let FBOId(id) = *self;
         gl::bind_framebuffer(gl::FRAMEBUFFER, id);
+        gl::bind_framebuffer(gl::READ_FRAMEBUFFER, id);
     }
 }
 
@@ -199,7 +200,7 @@ impl Device {
             vaos: HashMap::new(),
             //fbos: HashMap::new(),
 
-            next_vao_id: 0,
+            next_vao_id: 1,
         }
     }
 
@@ -479,6 +480,12 @@ impl Device {
         debug_assert!(self.inside_frame);
         let ProgramId(program_id) = program_id;
         UniformLocation(gl::get_uniform_location(program_id, name))
+    }
+
+    pub fn set_uniform_1f(&self, uniform: UniformLocation, x: f32) {
+        debug_assert!(self.inside_frame);
+        let UniformLocation(location) = uniform;
+        gl::uniform_1f(location, x);
     }
 
     pub fn set_uniform_4f(&self,

--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -1,6 +1,6 @@
 use app_units::Au;
 use device::{ProgramId, TextureId};
-use euclid::{Point2D, Size2D, Rect};
+use euclid::{Point2D, Rect, Size2D};
 use std::collections::HashMap;
 use string_cache::Atom;
 use types::{MixBlendMode};
@@ -194,6 +194,8 @@ pub enum RenderTargetMode {
 pub enum TextureUpdateDetails {
     Blit(Vec<u8>),
     BorderRadius(Au, Au, Au, Au),
+    /// Blur radius and border radius, respectively.
+    BoxShadowCorner(Au, Au),
 }
 
 pub enum TextureUpdateOp {
@@ -317,3 +319,19 @@ pub struct ClipRectResult {
     pub u1: f32,
     pub v1: f32,
 }
+
+impl ClipRectResult {
+    pub fn from_rects(rect: &Rect<f32>, uv: &Rect<f32>) -> ClipRectResult {
+        ClipRectResult {
+            x0: rect.origin.x,
+            y0: rect.origin.y,
+            x1: rect.max_x(),
+            y1: rect.max_y(),
+            u0: uv.origin.x,
+            v0: uv.origin.y,
+            u1: uv.max_x(),
+            v1: uv.max_y(),
+        }
+    }
+}
+

--- a/src/render_backend.rs
+++ b/src/render_backend.rs
@@ -20,7 +20,8 @@ use std::sync::mpsc::{Sender, Receiver};
 use std::thread;
 use string_cache::Atom;
 use texture_cache::{TextureCache, TextureCacheItem};
-use types::{DisplayListID, Epoch, BorderDisplayItem, BorderRadiusRasterOp, RectangleDisplayItem};
+use types::{DisplayListID, Epoch, BorderDisplayItem, BorderRadiusRasterOp};
+use types::{BoxShadowCornerRasterOp, RectangleDisplayItem};
 use types::{Glyph, GradientStop, DisplayListMode, RasterItem, ClipRegion};
 use types::{GlyphInstance, ImageID, DrawList, ImageFormat, BoxShadowClipMode, DisplayItem};
 use types::{PipelineId, RenderNotifier, StackingContext, SpecificDisplayItem, ColorF, DrawListID};
@@ -41,6 +42,17 @@ type RenderItemKeyArray = Vec<RenderItemKey>;
 static FONT_CONTEXT_COUNT: AtomicUsize = ATOMIC_USIZE_INIT;
 
 thread_local!(pub static FONT_CONTEXT: RefCell<FontContext> = RefCell::new(FontContext::new()));
+
+static MAX_RECT: Rect<f32> = Rect {
+    origin: Point2D {
+        x: -1000.0,
+        y: -1000.0,
+    },
+    size: Size2D {
+        width: 10000.0,
+        height: 10000.0,
+    },
+};
 
 #[derive(Clone, Copy, Debug, Ord, PartialOrd, PartialEq, Eq)]
 struct RenderTargetIndex(u32);
@@ -859,7 +871,7 @@ impl AABBTreeNode {
             let (display_item, draw_context) = flat_draw_lists.get_item_and_draw_context(key);
 
             // TODO: This doesn't propagate the stacking context clip region!
-            let clip_rect = Rect::new(Point2D::new(-1000.0, -1000.0), Size2D::new(10000.0, 10000.0));// &display_item.clip.main;
+            let clip_rect = MAX_RECT; // &display_item.clip.main;
 
             match display_item.item {
                 SpecificDisplayItem::Image(ref info) => {
@@ -889,6 +901,7 @@ impl AABBTreeNode {
                                                 draw_context,
                                                 &display_item.rect,
                                                 &clip_rect,
+                                                BoxShadowClipMode::Inset,
                                                 white_image_info,
                                                 mask_image_info,
                                                 &info.color);
@@ -913,9 +926,12 @@ impl AABBTreeNode {
                                                  &info.color,
                                                  info.blur_radius,
                                                  info.spread_radius,
+                                                 info.border_radius,
                                                  info.clip_mode,
                                                  white_image_info,
-                                                 mask_image_info);
+                                                 mask_image_info,
+                                                 raster_to_image_map,
+                                                 texture_cache);
                 }
                 SpecificDisplayItem::Border(ref info) => {
                     compiled_node.add_border(key,
@@ -1580,38 +1596,18 @@ impl CompiledNode {
                      draw_context: &DrawContext,
                      rect: &Rect<f32>,
                      clip: &Rect<f32>,
+                     clip_mode: BoxShadowClipMode,
                      image_info: &TextureCacheItem,
                      dummy_mask_image: &TextureCacheItem,
                      color: &ColorF) {
-        if rect.size.width > 0.0 && rect.size.height > 0.0 {
-            let uv_origin = Point2D::new(image_info.u0, image_info.v0);
-            let uv_size = Size2D::new(image_info.u1 - image_info.u0,
-                                      image_info.v1 - image_info.v0);
-            let uv = Rect::new(uv_origin, uv_size);
-
-            let clip_result = clipper::clip_rect_pos_uv(rect, &uv, clip);
-
-            if let Some(cr) = clip_result {
-                let render_item = RenderItem {
-                    sort_key: sort_key.clone(),
-                    info: RenderItemInfo::Draw(DrawRenderItem {
-                        pass: util::get_render_pass(color, image_info.format),
-                        color_texture_id: image_info.texture_id,
-                        mask_texture_id: dummy_mask_image.texture_id,
-                        primitive: Primitive::Rectangles,
-                        vertex_count: 4,
-                        first_vertex: self.vertex_buffer.len(),
-                    }),
-                };
-
-                self.vertex_buffer.push(cr.x0, cr.y0, color, cr.u0, cr.v0, draw_context);
-                self.vertex_buffer.push(cr.x1, cr.y0, color, cr.u1, cr.v0, draw_context);
-                self.vertex_buffer.push(cr.x0, cr.y1, color, cr.u0, cr.v1, draw_context);
-                self.vertex_buffer.push(cr.x1, cr.y1, color, cr.u1, cr.v1, draw_context);
-
-                self.render_items.push(render_item);
-            }
-        }
+        self.add_axis_aligned_gradient(sort_key,
+                                       draw_context,
+                                       rect,
+                                       clip,
+                                       clip_mode,
+                                       image_info,
+                                       dummy_mask_image,
+                                       &[*color, *color, *color, *color])
     }
 
     fn add_composite(&mut self,
@@ -1648,7 +1644,7 @@ impl CompiledNode {
                  dummy_mask_image: &TextureCacheItem,
                  color: &ColorF) {
 
-        let pass = util::get_render_pass(&color, image_info.format);
+        let pass = util::get_render_pass(&[*color], image_info.format);
         let first_vertex = self.vertex_buffer.len();
         let mut vertex_count = 0;
 
@@ -1805,16 +1801,57 @@ impl CompiledNode {
         }
     }
 
+    // Colors are in the order: top left, top right, bottom right, bottom left.
+    fn add_axis_aligned_gradient(&mut self,
+                                 sort_key: &DisplayItemKey,
+                                 draw_context: &DrawContext,
+                                 rect: &Rect<f32>,
+                                 clip: &Rect<f32>,
+                                 clip_mode: BoxShadowClipMode,
+                                 image_info: &TextureCacheItem,
+                                 dummy_mask_image: &TextureCacheItem,
+                                 colors: &[ColorF; 4]) {
+        if rect.size.width == 0.0 || rect.size.height == 0.0 {
+            return
+        }
+
+        let uv_origin = Point2D::new(image_info.u0, image_info.v0);
+        let uv_size = Size2D::new(image_info.u1 - image_info.u0, image_info.v1 - image_info.v0);
+        let uv = Rect::new(uv_origin, uv_size);
+
+        // TODO(pcwalton): Clip colors too!
+        for cr in clipper::clip_rect_with_mode_pos_uv(rect, &uv, clip, clip_mode) {
+            let render_item = RenderItem {
+                sort_key: sort_key.clone(),
+                info: RenderItemInfo::Draw(DrawRenderItem {
+                    pass: util::get_render_pass(colors, image_info.format),
+                    color_texture_id: image_info.texture_id,
+                    mask_texture_id: dummy_mask_image.texture_id,
+                    primitive: Primitive::Rectangles,
+                    vertex_count: 4,
+                    first_vertex: self.vertex_buffer.len(),
+                }),
+            };
+
+            self.vertex_buffer.push(cr.x0, cr.y0, &colors[0], cr.u0, cr.v0, draw_context);
+            self.vertex_buffer.push(cr.x1, cr.y0, &colors[1], cr.u1, cr.v0, draw_context);
+            self.vertex_buffer.push(cr.x0, cr.y1, &colors[3], cr.u0, cr.v1, draw_context);
+            self.vertex_buffer.push(cr.x1, cr.y1, &colors[2], cr.u1, cr.v1, draw_context);
+
+            self.render_items.push(render_item);
+        }
+    }
+
     fn add_gradient(&mut self,
                     sort_key: &DisplayItemKey,
                     draw_context: &DrawContext,
                     rect: &Rect<f32>,
                     start_point: &Point2D<f32>,
                     end_point: &Point2D<f32>,
-                    stops: &Vec<GradientStop>,
+                    stops: &[GradientStop],
                     image: &TextureCacheItem,
                     dummy_mask_image: &TextureCacheItem) {
-        assert!(stops.len() >= 2);
+        debug_assert!(stops.len() >= 2);
 
         let x0 = rect.origin.x;
         let x1 = x0 + rect.size.width;
@@ -1903,20 +1940,176 @@ impl CompiledNode {
                       color: &ColorF,
                       blur_radius: f32,
                       spread_radius: f32,
+                      border_radius: f32,
                       clip_mode: BoxShadowClipMode,
-                      image: &TextureCacheItem,
-                      dummy_mask_image: &TextureCacheItem) {
-        match (blur_radius, spread_radius, clip_mode) {
-            (0.0, 0.0, BoxShadowClipMode::None) => {
-                let mut rect = box_bounds.clone();
-                rect.origin.x += box_offset.x;
-                rect.origin.y += box_offset.y;
-                self.add_rectangle(sort_key, draw_context, &rect, clip, image, dummy_mask_image, color);
-            }
-            _ => {
-                //println!("TODO: BoxShadow {:?} {:?} {:?}", blur_radius, spread_radius, clip_mode);
-            }
+                      white_image: &TextureCacheItem,
+                      dummy_mask_image: &TextureCacheItem,
+                      raster_to_image_map: &HashMap<RasterItem, ImageID, DefaultState<FnvHasher>>,
+                      texture_cache: &TextureCache) {
+        let mut rect = box_bounds.clone();
+        rect.origin.x += box_offset.x;
+        rect.origin.y += box_offset.y;
+
+        // Fast path.
+        if blur_radius == 0.0 && spread_radius == 0.0 && clip_mode == BoxShadowClipMode::None {
+            self.add_rectangle(sort_key,
+                               draw_context,
+                               &rect,
+                               clip,
+                               BoxShadowClipMode::Inset,
+                               white_image,
+                               dummy_mask_image,
+                               color);
+            return;
         }
+
+        // Draw the corners.
+        //
+        //      +--+------------------+--+
+        //      |##|                  |##|
+        //      +--+------------------+--+
+        //      |  |                  |  |
+        //      |  |                  |  |
+        //      |  |                  |  |
+        //      +--+------------------+--+
+        //      |##|                  |##|
+        //      +--+------------------+--+
+
+        let side_radius = border_radius + blur_radius;
+        let tl_outer = rect.origin;
+        let tl_inner = tl_outer + Point2D::new(side_radius, side_radius);
+        let tr_outer = rect.top_right();
+        let tr_inner = tr_outer + Point2D::new(-side_radius, side_radius);
+        let bl_outer = rect.bottom_left();
+        let bl_inner = bl_outer + Point2D::new(side_radius, -side_radius);
+        let br_outer = rect.bottom_right();
+        let br_inner = br_outer + Point2D::new(-side_radius, -side_radius);
+
+        self.add_box_shadow_corner(sort_key,
+                                   draw_context,
+                                   &tl_outer,
+                                   &tl_inner,
+                                   box_bounds,
+                                   &color,
+                                   blur_radius,
+                                   border_radius,
+                                   clip_mode,
+                                   white_image,
+                                   dummy_mask_image,
+                                   raster_to_image_map,
+                                   texture_cache);
+        self.add_box_shadow_corner(sort_key,
+                                   draw_context,
+                                   &tr_outer,
+                                   &tr_inner,
+                                   box_bounds,
+                                   &color,
+                                   blur_radius,
+                                   border_radius,
+                                   clip_mode,
+                                   white_image,
+                                   dummy_mask_image,
+                                   raster_to_image_map,
+                                   texture_cache);
+        self.add_box_shadow_corner(sort_key,
+                                   draw_context,
+                                   &bl_outer,
+                                   &bl_inner,
+                                   box_bounds,
+                                   &color,
+                                   blur_radius,
+                                   border_radius,
+                                   clip_mode,
+                                   white_image,
+                                   dummy_mask_image,
+                                   raster_to_image_map,
+                                   texture_cache);
+        self.add_box_shadow_corner(sort_key,
+                                   draw_context,
+                                   &br_outer,
+                                   &br_inner,
+                                   box_bounds,
+                                   &color,
+                                   blur_radius,
+                                   border_radius,
+                                   clip_mode,
+                                   white_image,
+                                   dummy_mask_image,
+                                   raster_to_image_map,
+                                   texture_cache);
+
+        // Draw the sides.
+        //
+        //      +--+------------------+--+
+        //      |  |##################|  |
+        //      +--+------------------+--+
+        //      |##|                  |##|
+        //      |##|                  |##|
+        //      |##|                  |##|
+        //      +--+------------------+--+
+        //      |  |##################|  |
+        //      +--+------------------+--+
+
+        let transparent = ColorF {
+            a: 0.0,
+            ..*color
+        };
+        let blur_diameter = blur_radius + blur_radius;
+        let twice_blur_diameter = blur_diameter + blur_diameter;
+        let twice_side_radius = side_radius + side_radius;
+        let horizontal_size = Size2D::new(rect.size.width - twice_side_radius, blur_diameter);
+        let vertical_size = Size2D::new(blur_diameter, rect.size.height - twice_side_radius);
+        let top_rect = Rect::new(tl_outer + Point2D::new(side_radius, 0.0), horizontal_size);
+        let right_rect = Rect::new(tr_outer + Point2D::new(-blur_diameter, side_radius),
+                                   vertical_size);
+        let bottom_rect = Rect::new(bl_outer + Point2D::new(side_radius, -blur_diameter),
+                                    horizontal_size);
+        let left_rect = Rect::new(tl_outer + Point2D::new(0.0, side_radius), vertical_size);
+
+        self.add_axis_aligned_gradient(sort_key,
+                                       draw_context,
+                                       &top_rect,
+                                       box_bounds,
+                                       clip_mode,
+                                       white_image,
+                                       dummy_mask_image,
+                                       &[transparent, transparent, *color, *color]);
+        self.add_axis_aligned_gradient(sort_key,
+                                       draw_context,
+                                       &right_rect,
+                                       box_bounds,
+                                       clip_mode,
+                                       white_image,
+                                       dummy_mask_image,
+                                       &[*color, transparent, transparent, *color]);
+        self.add_axis_aligned_gradient(sort_key,
+                                       draw_context,
+                                       &bottom_rect,
+                                       box_bounds,
+                                       clip_mode,
+                                       white_image,
+                                       dummy_mask_image,
+                                       &[*color, *color, transparent, transparent]);
+        self.add_axis_aligned_gradient(sort_key,
+                                       draw_context,
+                                       &left_rect,
+                                       box_bounds,
+                                       clip_mode,
+                                       white_image,
+                                       dummy_mask_image,
+                                       &[transparent, *color, *color, transparent]);
+
+        // Fill the center area.
+        self.add_rectangle(sort_key,
+                           draw_context,
+                           &Rect::new(tl_outer + Point2D::new(blur_diameter, blur_diameter),
+                                      Size2D::new(rect.size.width - twice_blur_diameter,
+                                                  rect.size.height - twice_blur_diameter)),
+                           box_bounds,
+                           clip_mode,
+                           white_image,
+                           dummy_mask_image,
+                           color);
     }
 
     #[inline]
@@ -1977,26 +2170,77 @@ impl CompiledNode {
             }
         };
 
-        if color0.a > 0.0 || color1.a > 0.0 {
+        self.add_masked_rectangle(sort_key,
+                                  draw_context,
+                                  &v0,
+                                  &v1,
+                                  &MAX_RECT,
+                                  BoxShadowClipMode::None,
+                                  color0,
+                                  color1,
+                                  &white_image,
+                                  &mask_image);
+    }
+
+    fn add_masked_rectangle(&mut self,
+                            sort_key: &DisplayItemKey,
+                            draw_context: &DrawContext,
+                            v0: &Point2D<f32>,
+                            v1: &Point2D<f32>,
+                            clip: &Rect<f32>,
+                            clip_mode: BoxShadowClipMode,
+                            color0: &ColorF,
+                            color1: &ColorF,
+                            white_image: &TextureCacheItem,
+                            mask_image: &TextureCacheItem) {
+        if color0.a <= 0.0 || color1.a <= 0.0 {
+            return
+        }
+
+        let vertices_rect = Rect::new(*v0, Size2D::new(v1.x - v0.x, v1.y - v0.y));
+        let mask_uv_rect = Rect::new(Point2D::new(mask_image.u0, mask_image.v0),
+                                     Size2D::new(mask_image.u1 - mask_image.u0,
+                                                 mask_image.v1 - mask_image.v0));
+        for clip_result in clipper::clip_rect_with_mode_pos_uv(&vertices_rect,
+                                                               &mask_uv_rect,
+                                                               clip,
+                                                               clip_mode) {
             let item = RenderItem {
                 sort_key: sort_key.clone(),
                 info: RenderItemInfo::Draw(DrawRenderItem {
                     pass: RenderPass::Alpha,
                     color_texture_id: white_image.texture_id,
                     mask_texture_id: mask_image.texture_id,
-                    primitive: Primitive::Triangles,
+                    primitive: Primitive::Rectangles,
                     first_vertex: self.vertex_buffer.len(),
-                    vertex_count: 6,
+                    vertex_count: 4,
                 }),
             };
 
-            self.vertex_buffer.push_masked(v0.x, v0.y, color0, mask_image.u0, mask_image.v0, draw_context);
-            self.vertex_buffer.push_masked(v1.x, v1.y, color0, mask_image.u1, mask_image.v1, draw_context);
-            self.vertex_buffer.push_masked(v0.x, v1.y, color0, mask_image.u0, mask_image.v1, draw_context);
-
-            self.vertex_buffer.push_masked(v0.x, v0.y, color1, mask_image.u0, mask_image.v0, draw_context);
-            self.vertex_buffer.push_masked(v1.x, v0.y, color1, mask_image.u1, mask_image.v0, draw_context);
-            self.vertex_buffer.push_masked(v1.x, v1.y, color1, mask_image.u1, mask_image.v1, draw_context);
+            self.vertex_buffer.push_masked(clip_result.x0,
+                                           clip_result.y0,
+                                           color0,
+                                           clip_result.u0,
+                                           clip_result.v0,
+                                           draw_context);
+            self.vertex_buffer.push_masked(clip_result.x1,
+                                           clip_result.y0,
+                                           color0,
+                                           clip_result.u1,
+                                           clip_result.v0,
+                                           draw_context);
+            self.vertex_buffer.push_masked(clip_result.x0,
+                                           clip_result.y1,
+                                           color1,
+                                           clip_result.u0,
+                                           clip_result.v1,
+                                           draw_context);
+            self.vertex_buffer.push_masked(clip_result.x1,
+                                           clip_result.y1,
+                                           color1,
+                                           clip_result.u1,
+                                           clip_result.v1,
+                                           draw_context);
 
             self.render_items.push(item);
         }
@@ -2117,6 +2361,52 @@ impl CompiledNode {
                                raster_to_image_map,
                                texture_cache);
     }
+
+    // FIXME(pcwalton): Assumes rectangles are well-formed with origin in TL
+    fn add_box_shadow_corner(&mut self,
+                             sort_key: &DisplayItemKey,
+                             draw_context: &DrawContext,
+                             top_left: &Point2D<f32>,
+                             bottom_right: &Point2D<f32>,
+                             box_bounds: &Rect<f32>,
+                             color: &ColorF,
+                             blur_radius: f32,
+                             border_radius: f32,
+                             clip_mode: BoxShadowClipMode,
+                             white_image: &TextureCacheItem,
+                             dummy_mask_image: &TextureCacheItem,
+                             raster_to_image_map:
+                                &HashMap<RasterItem, ImageID, DefaultState<FnvHasher>>,
+                             texture_cache: &TextureCache) {
+        let mask_image = match BoxShadowCornerRasterOp::create(blur_radius, border_radius) {
+            Some(raster_item) => {
+                let raster_item = RasterItem::BoxShadowCorner(raster_item);
+                let raster_item_id = raster_to_image_map[&raster_item];
+                texture_cache.get(raster_item_id)
+            }
+            None => dummy_mask_image,
+        };
+
+        let clip_rect = match clip_mode {
+            BoxShadowClipMode::Outset => *box_bounds,
+            BoxShadowClipMode::None => MAX_RECT,
+            BoxShadowClipMode::Inset => {
+                // TODO(pcwalton): Implement this.
+                MAX_RECT
+            }
+        };
+
+        self.add_masked_rectangle(sort_key,
+                                  draw_context,
+                                  top_left,
+                                  bottom_right,
+                                  &clip_rect,
+                                  clip_mode,
+                                  color,
+                                  color,
+                                  white_image,
+                                  &mask_image)
+    }
 }
 
 trait BuildRequiredResources {
@@ -2127,6 +2417,9 @@ trait RequiredResourceHelpers {
     fn add_radius(required_rasters: &mut HashSet<RasterItem, DefaultState<FnvHasher>>,
                   outer_radius: &Size2D<f32>,
                   inner_radius: &Size2D<f32>);
+    fn add_box_shadow_corner(required_rasters: &mut HashSet<RasterItem, DefaultState<FnvHasher>>,
+                             blur_radius: f32,
+                             border_radius: f32);
 }
 
 impl BuildRequiredResources for AABBTreeNode {
@@ -2162,8 +2455,12 @@ impl BuildRequiredResources for AABBTreeNode {
                 SpecificDisplayItem::Rectangle(..) => {}
                 SpecificDisplayItem::Iframe(..) => {}
                 SpecificDisplayItem::Gradient(..) => {}
-                SpecificDisplayItem::BoxShadow(..) => {}
                 SpecificDisplayItem::Composite(..) => {}
+                SpecificDisplayItem::BoxShadow(ref info) => {
+                    DrawList::add_box_shadow_corner(&mut resource_list.required_rasters,
+                                                    info.blur_radius,
+                                                    info.border_radius);
+                }
                 SpecificDisplayItem::Border(ref info) => {
                     DrawList::add_radius(&mut resource_list.required_rasters,
                                          &info.radius.top_left,
@@ -2191,6 +2488,14 @@ impl RequiredResourceHelpers for DrawList {
                   inner_radius: &Size2D<f32>) {
         if let Some(raster_item) = BorderRadiusRasterOp::create(outer_radius, inner_radius) {
             required_rasters.insert(RasterItem::BorderRadius(raster_item));
+        }
+    }
+
+    fn add_box_shadow_corner(required_rasters: &mut HashSet<RasterItem, DefaultState<FnvHasher>>,
+                             blur_radius: f32,
+                             border_radius: f32) {
+        if let Some(raster_item) = BoxShadowCornerRasterOp::create(blur_radius, border_radius) {
+            required_rasters.insert(RasterItem::BoxShadowCorner(raster_item));
         }
     }
 }

--- a/src/texture_cache.rs
+++ b/src/texture_cache.rs
@@ -264,6 +264,28 @@ impl TextureCache {
                                                                                    op.inner_radius_y)),
                 }
             }
+            &RasterItem::BoxShadowCorner(ref op) => {
+                let size = op.border_radius + op.blur_radius;
+                let allocation = self.allocate(image_id,
+                                               0,
+                                               0,
+                                               size.to_nearest_px() as u32,
+                                               size.to_nearest_px() as u32,
+                                               ImageFormat::A8);
+
+                // TODO(pcwalton): Handle large box shadows not fitting in texture cache page.
+                assert!(allocation.kind == AllocationKind::TexturePage);
+
+                TextureUpdate {
+                    id: allocation.texture_id,
+                    op: TextureUpdateOp::Update(
+                        allocation.x,
+                        allocation.y,
+                        size.to_nearest_px() as u32,
+                        size.to_nearest_px() as u32,
+                        TextureUpdateDetails::BoxShadowCorner(op.blur_radius, op.border_radius)),
+                }
+            }
         };
 
         self.pending_updates.push(update_op);

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,7 +11,7 @@ pub enum ImageFormat {
     RGBA8,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct ColorF {
     pub r: f32,
     pub g: f32,
@@ -102,7 +102,7 @@ impl ImageID {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum BoxShadowClipMode {
     None,
     Outset,
@@ -253,6 +253,7 @@ pub struct BoxShadowDisplayItem {
     pub color: ColorF,
     pub blur_radius: f32,
     pub spread_radius: f32,
+    pub border_radius: f32,
     pub clip_mode: BoxShadowClipMode,
 }
 
@@ -323,8 +324,28 @@ impl BorderRadiusRasterOp {
 }
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub struct BoxShadowCornerRasterOp {
+    pub blur_radius: Au,
+    pub border_radius: Au,
+}
+
+impl BoxShadowCornerRasterOp {
+    pub fn create(blur_radius: f32, border_radius: f32) -> Option<BoxShadowCornerRasterOp> {
+        if blur_radius > 0.0 || border_radius > 0.0 {
+            Some(BoxShadowCornerRasterOp {
+                blur_radius: Au::from_f32_px(blur_radius),
+                border_radius: Au::from_f32_px(border_radius),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub enum RasterItem {
     BorderRadius(BorderRadiusRasterOp),
+    BoxShadowCorner(BoxShadowCornerRasterOp),
 }
 
 pub struct DrawList {
@@ -486,6 +507,7 @@ impl DisplayListBuilder {
                            color: ColorF,
                            blur_radius: f32,
                            spread_radius: f32,
+                           border_radius: f32,
                            clip_mode: BoxShadowClipMode) {
         let item = BoxShadowDisplayItem {
             box_bounds: box_bounds,
@@ -493,6 +515,7 @@ impl DisplayListBuilder {
             color: color,
             blur_radius: blur_radius,
             spread_radius: spread_radius,
+            border_radius: border_radius,
             clip_mode: clip_mode,
         };
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -20,17 +20,18 @@ impl ProfileScope {
 
 impl Drop for ProfileScope {
     fn drop(&mut self) {
-        let t1 = precise_time_ns();
-        let ms = (t1 - self.t0) as f64 / 1000000f64;
-        //if ms > 0.1 {
+        if self.name.chars().next() != Some(' ') {
+            let t1 = precise_time_ns();
+            let ms = (t1 - self.t0) as f64 / 1000000f64;
+            //if ms > 0.1 {
             println!("{} {}", self.name, ms);
-        //}
+        }
     }
 }
 
-pub fn get_render_pass(color: &ColorF, format: ImageFormat) -> RenderPass {
-    if color.a < 1.0 {
-        return RenderPass::Alpha;
+pub fn get_render_pass(colors: &[ColorF], format: ImageFormat) -> RenderPass {
+    if colors.iter().any(|color| color.a < 1.0) {
+        return RenderPass::Alpha
     }
 
     match format {


### PR DESCRIPTION
Known issues:

* Clipping out does not clip the uv coordinates properly.

* Clipping to rounded rectangle corners does not work yet.

* Box shadows with elliptical radii are unsupported (also in master
  Servo).

* Box shadows with heterogeneous radii for each corner are unsupported
  (also in master Servo).

This PR depends on some changes to Servo to support the new border
radius field in box shadow display items: servo/servo#7896

r? @glennw