### PR TITLE
Implement clipping for `border-radius` for solid colors and images.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ mod texture_cache;
 pub use types::{ImageID, StackingLevel, DisplayListID, StackingContext, DisplayListBuilder};
 pub use types::{ColorF, ImageFormat, GradientStop, PipelineId, GlyphInstance, RenderNotifier};
 pub use types::{BorderSide, BorderRadius, BorderStyle, Epoch, BoxShadowClipMode, ClipRegion};
-pub use types::{ScrollLayerId, MixBlendMode};
+pub use types::{ScrollLayerId, MixBlendMode, ComplexClipRegion};
 pub use render_api::RenderApi;
 pub use renderer::Renderer;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -131,7 +131,7 @@ pub struct GradientStop {
     pub color: ColorF,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct BorderRadius {
     pub top_left: Size2D<f32>,
     pub top_right: Size2D<f32>,
@@ -633,12 +633,31 @@ impl Glyph {
 #[derive(Debug, Clone)]
 pub struct ClipRegion {
     pub main: Rect<f32>,
+    pub complex: Vec<ComplexClipRegion>,
 }
 
 impl ClipRegion {
-    pub fn new(rect: Rect<f32>) -> ClipRegion {
+    pub fn new(rect: Rect<f32>, complex: Vec<ComplexClipRegion>) -> ClipRegion {
         ClipRegion {
             main: rect,
+            complex: complex,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ComplexClipRegion {
+    /// The boundaries of the rectangle.
+    pub rect: Rect<f32>,
+    /// Border radii of this rectangle.
+    pub radii: BorderRadius,
+}
+
+impl ComplexClipRegion {
+    pub fn new(rect: Rect<f32>, radii: BorderRadius) -> ComplexClipRegion {
+        ComplexClipRegion {
+            rect: rect,
+            radii: radii,
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,5 @@
 use time::precise_time_ns;
-use internal_types::RenderPass;
+use internal_types::{ClipRectToRegionMaskResult, RenderPass};
 use types::{ColorF, ImageFormat};
 
 #[allow(dead_code)]
@@ -29,8 +29,11 @@ impl Drop for ProfileScope {
     }
 }
 
-pub fn get_render_pass(colors: &[ColorF], format: ImageFormat) -> RenderPass {
-    if colors.iter().any(|color| color.a < 1.0) {
+pub fn get_render_pass(colors: &[ColorF],
+                       format: ImageFormat,
+                       mask_result: &Option<ClipRectToRegionMaskResult>)
+                       -> RenderPass {
+    if colors.iter().any(|color| color.a < 1.0) || mask_result.is_some() {
         return RenderPass::Alpha
     }
 


### PR DESCRIPTION
Known issues:

* Gradients are not clipped yet because they need full
  Sutherland-Hodgman clipping.

* Clipping won't work right if borders do not have all the same size.

* Clipping won't work right when multiple rounded borders intersect one
  another.

* There are some known extraneous polygons when an actual border is
  present and something inside is clipped.

* Clipping doesn't work right for `overflow: hidden`. (This is a Servo
  bug.)