### PR TITLE
Implement dotted borders.

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -139,7 +139,7 @@ pub struct BorderRadius {
     pub bottom_right: Size2D<f32>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum BorderStyle {
     None,
     Solid,


### PR DESCRIPTION
Known issues:

* The corners are not dotted. This affects dashed borders too. The
  simple fix will be to disable corner drawing if there is no
  border-radius.

* Nearest-neighbor texture sampling doesn't work well if the border dots
  are an odd number of pixels. We'll need to make some sort of policy
  decision here as to what to do, as this may come up in other
  situations, so I'll defer the fix for that pending further discussion.