### PR TITLE
Various improvements to batching system.

### DIFF
--- a/res/glyph.vs.glsl
+++ b/res/glyph.vs.glsl
@@ -1,8 +1,12 @@
+#version 110
+
 attribute vec3 aPosition;
 attribute vec2 aTexCoord;
 attribute vec4 aColor;
+attribute vec4 aMatrixIndex;
 
 uniform mat4 uTransform;
+uniform mat4 uMatrixPalette[32];
 
 varying vec4 vColor;
 varying vec2 vTexCoord;
@@ -11,5 +15,7 @@ void main(void)
 {
 	vColor = aColor;
 	vTexCoord = aTexCoord;
-    gl_Position = uTransform * vec4(aPosition, 1.0);
+
+	mat4 matrix = uMatrixPalette[int(aMatrixIndex.x)];
+    gl_Position = uTransform * matrix * vec4(aPosition, 1.0);
 }

--- a/res/quad.vs.glsl
+++ b/res/quad.vs.glsl
@@ -1,9 +1,13 @@
+#version 110
+
 attribute vec3 aPosition;
 attribute vec2 aColorTexCoord;
 attribute vec2 aMaskTexCoord;
 attribute vec4 aColor;
+attribute vec4 aMatrixIndex;
 
 uniform mat4 uTransform;
+uniform mat4 uMatrixPalette[32];
 
 varying vec4 vColor;
 varying vec2 vColorTexCoord;
@@ -14,5 +18,7 @@ void main(void)
 	vColor = aColor;
 	vColorTexCoord = aColorTexCoord;
 	vMaskTexCoord = aMaskTexCoord;
-    gl_Position = uTransform * vec4(aPosition, 1.0);
+
+	mat4 matrix = uMatrixPalette[int(aMatrixIndex.x)];
+    gl_Position = uTransform * matrix * vec4(aPosition, 1.0);
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,6 +3,9 @@ use euclid::{Point2D, Rect, Size2D, Matrix4};
 use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 use string_cache::Atom;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NodeIndex(pub u32);
+
 #[derive(Debug, Clone, Copy)]
 pub enum ImageFormat {
     Invalid,
@@ -58,7 +61,7 @@ pub struct PipelineId(pub u32, pub u32);
 static RESOURCE_ID_COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
 
 #[inline]
-fn new_resource_id() -> usize {
+pub fn new_resource_id() -> usize {
     RESOURCE_ID_COUNTER.fetch_add(1, Ordering::SeqCst)
 }
 
@@ -302,6 +305,8 @@ pub struct DisplayItem {
     pub item: SpecificDisplayItem,
     pub rect: Rect<f32>,
     pub clip: ClipRegion,
+
+    pub node_index: Option<NodeIndex>,
 }
 
 pub enum DisplayListMode {
@@ -433,6 +438,7 @@ impl DisplayListBuilder {
             item: SpecificDisplayItem::Rectangle(item),
             rect: rect,
             clip: clip,
+            node_index: None,
         };
 
         self.push_item(level, display_item);
@@ -453,6 +459,7 @@ impl DisplayListBuilder {
             item: SpecificDisplayItem::Image(item),
             rect: rect,
             clip: clip,
+            node_index: None,
         };
 
         self.push_item(level, display_item);
@@ -479,6 +486,7 @@ impl DisplayListBuilder {
             item: SpecificDisplayItem::Text(item),
             rect: rect,
             clip: clip,
+            node_index: None,
         };
 
         self.push_item(level, display_item);
@@ -505,6 +513,7 @@ impl DisplayListBuilder {
             item: SpecificDisplayItem::Border(item),
             rect: rect,
             clip: clip,
+            node_index: None,
         };
 
         self.push_item(level, display_item);
@@ -535,6 +544,7 @@ impl DisplayListBuilder {
             item: SpecificDisplayItem::BoxShadow(item),
             rect: rect,
             clip: clip,
+            node_index: None,
         };
 
         self.push_item(level, display_item);
@@ -557,6 +567,7 @@ impl DisplayListBuilder {
             item: SpecificDisplayItem::Gradient(item),
             rect: rect,
             clip: clip,
+            node_index: None,
         };
 
         self.push_item(level, display_item);
@@ -579,6 +590,7 @@ impl DisplayListBuilder {
             item: SpecificDisplayItem::Iframe(item),
             rect: rect,
             clip: clip,
+            node_index: None,
         };
 
         self.push_item(level, display_item);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,4 @@
+use euclid::{Matrix4, Point2D, Rect, Size2D};
 use time::precise_time_ns;
 use internal_types::{ClipRectToRegionMaskResult, RenderPass};
 use types::{ColorF, ImageFormat};
@@ -42,5 +43,38 @@ pub fn get_render_pass(colors: &[ColorF],
         ImageFormat::RGBA8 => RenderPass::Alpha,
         ImageFormat::RGB8 => RenderPass::Opaque,
         ImageFormat::Invalid => unreachable!(),
+    }
+}
+
+// TODO: Implement these in euclid!
+pub trait MatrixHelpers {
+    fn transform_rect(&self, rect: &Rect<f32>) -> Rect<f32>;
+}
+
+impl MatrixHelpers for Matrix4 {
+    #[inline]
+    fn transform_rect(&self, rect: &Rect<f32>) -> Rect<f32> {
+        let top_left = self.transform_point(&rect.origin);
+        let top_right = self.transform_point(&rect.top_right());
+        let bottom_left = self.transform_point(&rect.bottom_left());
+        let bottom_right = self.transform_point(&rect.bottom_right());
+        let (mut min_x, mut min_y) = (top_left.x.clone(), top_left.y.clone());
+        let (mut max_x, mut max_y) = (min_x.clone(), min_y.clone());
+        for point in [ top_right, bottom_left, bottom_right ].iter() {
+            if point.x < min_x {
+                min_x = point.x.clone()
+            }
+            if point.x > max_x {
+                max_x = point.x.clone()
+            }
+            if point.y < min_y {
+                min_y = point.y.clone()
+            }
+            if point.y > max_y {
+                max_y = point.y.clone()
+            }
+        }
+        Rect::new(Point2D::new(min_x.clone(), min_y.clone()),
+                  Size2D::new(max_x - min_x, max_y - min_y))
     }
 }


### PR DESCRIPTION
* Batches are now built in parallel during compile_node.
* Batches are cached in GPU VBOs.
* Vertex shader now handles:
 * Transforms
 * Stacking context offsets
 * Scroll offsets
 * Pixel snapping

There is still a lot of general code cleanup and simple optimizations to make, but this fixes up the major CPU bottlenecks I'm aware of.

Batch creation is now significantly faster (and runs in parallel), and scrolling is a lot faster than previously.