### PR TITLE
Implement the CSS `filter` property.

### DIFF
--- a/res/filter.fs.glsl
+++ b/res/filter.fs.glsl
@@ -1,0 +1,149 @@
+#version 110
+
+#ifdef GL_ES
+    precision mediump float;
+#endif
+
+uniform sampler2D sDiffuse;
+uniform sampler2D sMask;
+uniform vec4 uFilterParams;
+uniform vec2 uTextureSize;
+
+varying vec2 vColorTexCoord;
+varying vec2 vMaskTexCoord;
+
+vec3 rgbToHsv(vec3 c) {
+    float value = max(max(c.r, c.g), c.b);
+
+    float chroma = value - min(min(c.r, c.g), c.b);
+    if (chroma == 0.0) {
+        return vec3(0.0);
+    }
+    float saturation = chroma / value;
+
+    float hue;
+    if (c.r == value)
+        hue = (c.g - c.b) / chroma;
+    else if (c.g == value)
+        hue = 2.0 + (c.b - c.r) / chroma;
+    else if (c.b == value)
+        hue = 4.0 + (c.r - c.g) / chroma;
+
+    hue *= 1.0/6.0;
+    if (hue < 0.0)
+        hue += 1.0;
+    return vec3(hue, saturation, value);
+}
+
+vec3 hsvToRgb(vec3 c) {
+    if (c.s == 0.0) {
+        return vec3(c.z);
+    }
+
+    float hue = c.x * 6.0;
+    int sector = int(hue);
+    float residualHue = hue - float(sector);
+
+    vec3 pqt = c.z * vec3(1.0 - c.y, 1.0 - c.y * residualHue, 1.0 - c.y * (1.0 - residualHue));
+    if (sector == 0)
+        return vec3(c.z, pqt.z, pqt.x);
+    if (sector == 1)
+        return vec3(pqt.y, c.z, pqt.x);
+    if (sector == 2)
+        return vec3(pqt.x, c.z, pqt.z);
+    if (sector == 3)
+        return vec3(pqt.x, pqt.y, c.z);
+    if (sector == 4)
+        return vec3(pqt.z, pqt.x, c.z);
+    return vec3(c.z, pqt.x, pqt.y);
+}
+
+float gauss(float x, float sigma) {
+    return (1.0 / sqrt(6.283185307179586 * sigma * sigma)) * exp(-(x * x) / (2.0 * sigma * sigma));
+}
+
+vec4 Blur(float radius, vec2 direction) {
+    int range = int(radius) * 3;
+    float sigma = radius / 2.0;
+    vec4 color = vec4(0.0);
+    for (int offset = -range; offset <= range; offset++) {
+        float offsetF = float(offset);
+        vec2 texCoord = vColorTexCoord + vec2(offsetF) / uTextureSize * direction;
+        vec4 x = texCoord.x >= 0.0 &&
+            texCoord.x <= 1.0 &&
+            texCoord.y >= 0.0 &&
+            texCoord.y <= 1.0 ?
+            texture2D(sDiffuse, texCoord) :
+            vec4(0.0);
+        color += x * gauss(offsetF, sigma);
+    }
+    return color;
+}
+
+vec4 Contrast(vec4 Cs, float amount) {
+    return vec4(Cs.rgb * amount - 0.5 * amount + 0.5, 1.0);
+}
+
+vec4 Grayscale(vec4 Cs, float amount) {
+    float ia = 1.0 - amount;
+    return mat4(vec4(0.2126 + 0.7874 * ia, 0.2126 - 0.2126 * ia, 0.2126 - 0.2126 * ia, 0.0),
+                vec4(0.7152 - 0.7152 * ia, 0.7152 + 0.2848 * ia, 0.7152 - 0.7152 * ia, 0.0),
+                vec4(0.0722 - 0.0722 * ia, 0.0722 - 0.0722 * ia, 0.0722 + 0.9278 * ia, 0.0),
+                vec4(0.0, 0.0, 0.0, 1.0)) * Cs;
+}
+
+vec4 HueRotate(vec4 Cs, float amount) {
+    vec3 CsHsv = rgbToHsv(Cs.rgb);
+    CsHsv.x = mod(CsHsv.x + amount / 6.283185307179586, 1.0);
+    return vec4(hsvToRgb(CsHsv), Cs.a);
+}
+
+vec4 Invert(vec4 Cs, float amount) {
+    return mix(Cs, vec4(1.0, 1.0, 1.0, Cs.a) - vec4(Cs.rgb, 0.0), amount);
+}
+
+vec4 Saturate(vec4 Cs, float amount) {
+    return vec4(hsvToRgb(min(vec3(1.0, amount, 1.0) * rgbToHsv(Cs.rgb), vec3(1.0))), Cs.a);
+}
+
+vec4 Sepia(vec4 Cs, float amount) {
+    float ia = 1.0 - amount;
+    return mat4(vec4(0.393 + 0.607 * ia, 0.349 - 0.349 * ia, 0.272 - 0.272 * ia, 0.0),
+                vec4(0.769 - 0.769 * ia, 0.686 + 0.314 * ia, 0.534 - 0.534 * ia, 0.0),
+                vec4(0.189 - 0.189 * ia, 0.168 - 0.168 * ia, 0.131 + 0.869 * ia, 0.0),
+                vec4(0.0, 0.0, 0.0, 1.0)) * Cs;
+}
+
+void main(void)
+{
+    // TODO: May be best to have separate shaders (esp. on Tegra)
+    int filterOp = int(uFilterParams.x);
+    float amount = uFilterParams.y;
+
+    // Return yellow if none of the branches match (shouldn't happen).
+    vec4 result = vec4(1.0, 1.0, 0.0, 1.0);
+
+    if (filterOp == 0) {
+        // Gaussian blur is specially handled:
+        result = Blur(amount, uFilterParams.zw);
+    } else {
+        vec4 Cs = texture2D(sDiffuse, vColorTexCoord);
+
+        if (filterOp == 1) {
+            result = Contrast(Cs, amount);
+        } else if (filterOp == 2) {
+            result = Grayscale(Cs, amount);
+        } else if (filterOp == 3) {
+            result = HueRotate(Cs, amount);
+        } else if (filterOp == 4) {
+            result = Invert(Cs, amount);
+        } else if (filterOp == 5) {
+            result = Saturate(Cs, amount);
+        } else if (filterOp == 6) {
+            result = Sepia(Cs, amount);
+        }
+    }
+
+    gl_FragColor = result;
+}
+

--- a/res/filter.vs.glsl
+++ b/res/filter.vs.glsl
@@ -1,0 +1,17 @@
+#version 110
+
+attribute vec3 aPosition;
+attribute vec2 aColorTexCoord;
+attribute vec2 aMaskTexCoord;
+
+uniform mat4 uTransform;
+
+varying vec2 vColorTexCoord;
+varying vec2 vMaskTexCoord;
+
+void main(void)
+{
+	vColorTexCoord = aColorTexCoord;
+	vMaskTexCoord = aMaskTexCoord;
+    gl_Position = uTransform * vec4(aPosition, 1.0);
+}

--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -5,9 +5,9 @@ use renderbatch::RenderBatch;
 use std::collections::HashMap;
 use string_cache::Atom;
 use texture_cache::TextureCacheItem;
-use types::{MixBlendMode, new_resource_id};
 use types::{Epoch, ColorF, PipelineId, ImageFormat, DisplayListID, DrawListID};
-use types::{ImageID, StackingContext, DisplayListBuilder, DisplayListMode};
+use types::{ImageID, StackingContext, DisplayListBuilder, DisplayListMode, CompositionOp};
+use types::{new_resource_id};
 
 const UV_FLOAT_TO_FIXED: f32 = 65535.0;
 const COLOR_FLOAT_TO_FIXED: f32 = 255.0;
@@ -250,7 +250,7 @@ impl BatchUpdateList {
 
 #[derive(Clone)]
 pub struct CompositeInfo {
-    pub blend_mode: MixBlendMode,
+    pub operation: CompositionOp,
     pub rect: Rect<u32>,
     pub color_texture_id: TextureId,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ mod texture_cache;
 pub use types::{ImageID, StackingLevel, DisplayListID, StackingContext, DisplayListBuilder};
 pub use types::{ColorF, ImageFormat, GradientStop, PipelineId, GlyphInstance, RenderNotifier};
 pub use types::{BorderSide, BorderRadius, BorderStyle, Epoch, BoxShadowClipMode, ClipRegion};
-pub use types::{ScrollLayerId, MixBlendMode, ComplexClipRegion};
+pub use types::{ScrollLayerId, MixBlendMode, ComplexClipRegion, FilterOp};
 pub use render_api::RenderApi;
 pub use renderer::Renderer;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -174,6 +174,7 @@ pub struct StackingContext {
     pub perspective: Matrix4,
     pub establishes_3d_context: bool,
     pub mix_blend_mode: MixBlendMode,
+    pub filters: Vec<FilterOp>,
 }
 
 impl StackingContext {
@@ -184,7 +185,9 @@ impl StackingContext {
                transform: &Matrix4,
                perspective: &Matrix4,
                establishes_3d_context: bool,
-               mix_blend_mode: MixBlendMode) -> StackingContext {
+               mix_blend_mode: MixBlendMode,
+               filters: Vec<FilterOp>)
+               -> StackingContext {
         StackingContext {
             scroll_layer_id: scroll_layer_id,
             bounds: bounds,
@@ -196,6 +199,7 @@ impl StackingContext {
             perspective: perspective.clone(),
             establishes_3d_context: establishes_3d_context,
             mix_blend_mode: mix_blend_mode,
+            filters: filters,
         }
     }
 
@@ -285,7 +289,7 @@ pub struct IframeDisplayItem {
 #[derive(Debug)]
 pub struct CompositeDisplayItem {
     pub texture_id: RenderTargetID,
-    pub blend_mode: MixBlendMode,
+    pub operation: CompositionOp,
 }
 
 #[derive(Debug)]
@@ -699,3 +703,42 @@ pub enum MixBlendMode {
     Color,
     Luminosity,
 }
+
+#[derive(Clone, Copy, Debug)]
+pub enum LowLevelFilterOp {
+    Blur(Au, BlurDirection),
+    Brightness(f32),
+    Contrast(f32),
+    Grayscale(f32),
+    HueRotate(f32),
+    Invert(f32),
+    Opacity(f32),
+    Saturate(f32),
+    Sepia(f32),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum FilterOp {
+    Blur(Au),
+    Brightness(f32),
+    Contrast(f32),
+    Grayscale(f32),
+    HueRotate(f32),
+    Invert(f32),
+    Opacity(f32),
+    Saturate(f32),
+    Sepia(f32),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum BlurDirection {
+    Horizontal,
+    Vertical,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum CompositionOp {
+    MixBlend(MixBlendMode),
+    Filter(LowLevelFilterOp),
+}
+


### PR DESCRIPTION
The mechanism is largely the same as for `mix-blend-mode`.

Known issues:

* `drop-shadow` is unimplemented.

* `blur` does not properly blur the edges.

Both issues stem from the fact that we do not yet inflate bounding boxes for
filters and `mix-blend-mode`.