### PR TITLE
Implement various scrolling improvements.

### DIFF
--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -3,6 +3,7 @@ use device::{ProgramId, TextureId};
 use euclid::{Matrix4, Point2D, Rect, Size2D};
 use renderbatch::RenderBatch;
 use std::collections::HashMap;
+use std::sync::mpsc::Sender;
 use string_cache::Atom;
 use texture_cache::TextureCacheItem;
 use types::{Epoch, ColorF, PipelineId, ImageFormat, DisplayListID, DrawListID};
@@ -314,6 +315,7 @@ pub enum ApiMsg {
     SetRootStackingContext(StackingContext, ColorF, Epoch, PipelineId),
     SetRootPipeline(PipelineId),
     Scroll(Point2D<f32>),
+    TranslatePointToLayerSpace(Point2D<f32>, Sender<Point2D<f32>>),
 }
 
 pub enum ResultMsg {

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,5 +1,5 @@
 use aabbtree::AABBTree;
-use euclid::{Point2D, Rect};
+use euclid::{Point2D, Rect, Size2D};
 use internal_types::{BatchUpdate, BatchUpdateList, BatchUpdateOp};
 use types::NodeIndex;
 
@@ -7,16 +7,18 @@ pub struct Layer {
     // TODO: Remove pub from here if possible in the future
     pub aabb_tree: AABBTree,
     pub scroll_offset: Point2D<f32>,
+    pub scroll_boundaries: Size2D<f32>,
 }
 
 impl Layer {
-    pub fn new(scene_rect: &Rect<f32>) -> Layer {
+    pub fn new(scene_rect: &Rect<f32>, scroll_offset: &Point2D<f32>) -> Layer {
         let mut aabb_tree = AABBTree::new(512.0);
         aabb_tree.init(scene_rect);
 
         Layer {
             aabb_tree: aabb_tree,
-            scroll_offset: Point2D::zero(),
+            scroll_offset: *scroll_offset,
+            scroll_boundaries: Size2D::zero(),
         }
     }
 

--- a/src/render_api.rs
+++ b/src/render_api.rs
@@ -1,6 +1,6 @@
 use euclid::Point2D;
 use internal_types::ApiMsg;
-use std::sync::mpsc::Sender;
+use std::sync::mpsc::{self, Sender};
 use string_cache::Atom;
 use types::{PipelineId, ImageID, ImageFormat, StackingContext};
 use types::{ColorF, DisplayListID, DisplayListBuilder, Epoch};
@@ -59,4 +59,12 @@ impl RenderApi {
         let msg = ApiMsg::Scroll(delta);
         self.tx.send(msg).unwrap();
     }
+
+    pub fn translate_point_to_layer_space(&self, point: &Point2D<f32>) -> Point2D<f32> {
+        let (tx, rx) = mpsc::channel();
+        let msg = ApiMsg::TranslatePointToLayerSpace(*point, tx);
+        self.tx.send(msg).unwrap();
+        rx.recv().unwrap()
+    }
 }
+


### PR DESCRIPTION
* Persist layer scroll positions from paint to paint.

* Clamp scroll positions to the appropriate boundaries for each layer.

* Translate window-relative positions into layer-relative positions via a new
API.

This patch does not currently properly reset scroll positions on navigation,
because we don't have any notion of layer identity that differs from page to
page.