### PR TITLE
Add basic 3d transforms support.

### DIFF
--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -251,6 +251,16 @@ impl BatchUpdateList {
     }
 }
 
+// TODO(gw): Use bitflags crate for ClearInfo...
+// TODO(gw): Expand clear info to handle color, depth etc as needed.
+
+#[derive(Clone)]
+pub struct ClearInfo {
+    pub clear_color: bool,
+    pub clear_z: bool,
+    pub clear_stencil: bool,
+}
+
 #[derive(Clone)]
 pub struct CompositeInfo {
     pub operation: CompositionOp,
@@ -262,6 +272,7 @@ pub struct CompositeInfo {
 pub enum DrawCommandInfo {
     Batch(BatchId),
     Composite(CompositeInfo),
+    Clear(ClearInfo),
 }
 
 #[derive(Clone, Copy, Debug, Ord, PartialOrd, PartialEq, Eq, Hash)]

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -623,14 +623,30 @@ impl Renderer {
                              0,
                              (layer.size.width as f32 * self.device_pixel_ratio) as gl::GLint,
                              (layer.size.height as f32 * self.device_pixel_ratio) as gl::GLint);
-                gl::disable(gl::DEPTH_TEST);
+                gl::enable(gl::DEPTH_TEST);
+                gl::depth_func(gl::LEQUAL);
 
                 // Clear frame buffer
                 gl::clear_color(1.0, 1.0, 1.0, 1.0);
-                gl::clear(gl::COLOR_BUFFER_BIT);
+                gl::clear(gl::COLOR_BUFFER_BIT |
+                          gl::DEPTH_BUFFER_BIT |
+                          gl::STENCIL_BUFFER_BIT);
 
                 for cmd in &layer.commands {
                     match cmd.info {
+                        DrawCommandInfo::Clear(ref info) => {
+                            let mut clear_bits = 0;
+                            if info.clear_color {
+                                clear_bits |= gl::COLOR_BUFFER_BIT;
+                            }
+                            if info.clear_z {
+                                clear_bits |= gl::DEPTH_BUFFER_BIT;
+                            }
+                            if info.clear_stencil {
+                                clear_bits |= gl::STENCIL_BUFFER_BIT;
+                            }
+                            gl::clear(clear_bits);
+                        }
                         DrawCommandInfo::Batch(batch_id) => {
                             // TODO: probably worth sorting front to back to minimize overdraw (if profiling shows fragment / rop bound)
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -298,6 +298,13 @@ pub struct IframeDisplayItem {
 }
 
 #[derive(Debug)]
+pub struct ClearDisplayItem {
+    pub clear_color: bool,
+    pub clear_z: bool,
+    pub clear_stencil: bool,
+}
+
+#[derive(Debug)]
 pub struct CompositeDisplayItem {
     pub texture_id: RenderTargetID,
     pub operation: CompositionOp,
@@ -312,7 +319,10 @@ pub enum SpecificDisplayItem {
     BoxShadow(BoxShadowDisplayItem),
     Gradient(GradientDisplayItem),
     Iframe(IframeDisplayItem),
+
+    // Internal use only
     Composite(CompositeDisplayItem),
+    Clear(ClearDisplayItem),
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This makes it possible to run the Mirror room demo at:

https://github.com/glennw/MirrorRoom-CSS-3D/tree/servo-hacks

(There are a few issues with things clipping out when they shouldn't).