### PR TITLE
Add some simple batching fixes. Draw calls on GH from 146 -> 14.

### DIFF
--- a/src/aabbtree.rs
+++ b/src/aabbtree.rs
@@ -50,6 +50,11 @@ pub struct AABBTree {
     pub split_size: f32,
 }
 
+pub struct AABBTreeNodeInfo {
+    pub rect: Rect<f32>,
+    pub is_visible: bool,
+}
+
 impl AABBTree {
     pub fn new(split_size: f32) -> AABBTree {
         AABBTree {
@@ -100,12 +105,15 @@ impl AABBTree {
         &mut self.nodes[index as usize]
     }
 
-    pub fn node_rects(&self) -> Vec<Rect<f32>> {
-        let mut rects = Vec::new();
+    pub fn node_info(&self) -> Vec<AABBTreeNodeInfo> {
+        let mut info = Vec::new();
         for node in &self.nodes {
-            rects.push(node.actual_rect);
+            info.push(AABBTreeNodeInfo {
+                rect: node.actual_rect,
+                is_visible: node.is_visible,
+            });
         }
-        rects
+        info
     }
 
     #[inline]
@@ -194,7 +202,8 @@ impl AABBTree {
         let children = {
             let node = self.node_mut(node_index);
             if node.split_rect.intersects(rect) {
-                if node.src_items.len() > 0 {
+                if node.src_items.len() > 0 &&
+                   node.actual_rect.intersects(rect) {
                     node.is_visible = true;
                 }
                 node.children

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -12,7 +12,7 @@ pub struct Layer {
 
 impl Layer {
     pub fn new(scene_rect: &Rect<f32>, scroll_offset: &Point2D<f32>) -> Layer {
-        let mut aabb_tree = AABBTree::new(512.0);
+        let mut aabb_tree = AABBTree::new(1024.0);
         aabb_tree.init(scene_rect);
 
         Layer {

--- a/src/renderbatch.rs
+++ b/src/renderbatch.rs
@@ -42,12 +42,23 @@ impl RenderBatch {
                         program_id: ProgramId) -> bool {
         let matrix_ok = self.matrix_map.len() < MAX_MATRICES_PER_BATCH ||
                         self.matrix_map.contains_key(&key.draw_list_index);
+        let program_ok = program_id == self.program_id;
+        let color_texture_ok = color_texture_id == self.color_texture_id;
+        let mask_texture_ok = mask_texture_id == self.mask_texture_id;
+        let vertices_ok = self.vertices.len() < 65535;  // to ensure we can use u16 index buffers
 
-        program_id == self.program_id &&
-            color_texture_id == self.color_texture_id &&
-            mask_texture_id == self.mask_texture_id &&
-            self.vertices.len() < 65535 &&                  // to ensure we can use u16 index buffers
-            matrix_ok
+        let batch_ok = matrix_ok &&
+                       program_ok &&
+                       color_texture_ok &&
+                       mask_texture_ok &&
+                       vertices_ok;
+
+        if !batch_ok {
+            //println!("break batch! matrix={} program={} color={} mask={} vertices={} [{:?} vs {:?}]",
+            //         matrix_ok, program_ok, color_texture_ok, mask_texture_ok, vertices_ok, color_texture_id, self.color_texture_id);
+        }
+
+        batch_ok
     }
 
     pub fn add_draw_item(&mut self,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -132,10 +132,10 @@ impl Renderer {
         let texture_ids = device.create_texture_ids(1024);
         let mut texture_cache = TextureCache::new(texture_ids);
         let white_pixels: Vec<u8> = vec![
-            0xff, 0xff, 0xff,
-            0xff, 0xff, 0xff,
-            0xff, 0xff, 0xff,
-            0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff,
         ];
         let mask_pixels: Vec<u8> = vec![
             0xff, 0xff,
@@ -148,7 +148,7 @@ impl Renderer {
                              0,
                              2,
                              2,
-                             ImageFormat::RGB8,
+                             ImageFormat::RGBA8,
                              TextureInsertOp::Blit(white_pixels));
 
         let dummy_mask_image_id = ImageID::new();


### PR DESCRIPTION
(Relies on the unmerged PR to switch glyph rendering to RGBA8 textures for those numbers).

One of the major issues is that sometimes the batcher ping pongs between
textures when using the dummy white texture. This was previously RGB8
format, so any glyphs would break batching. It's now RGBA8 which means that
batching works well with glyphs. The proper fix will be to add a dummy white
image in both RGB8 and RGBA8 format - and make the batcher aware of this. It
can then select the dummy white image that will avoid breaking the batch.

Additionally, the AABB tree split threshold of 512 was resulting in nodes that were
around 256 pixels high on GH. This produces too many false overlap detections that
currently cause batch breaks. Switching to 1024 didn't seem to affect parallelism
of batch building on any sites I tested. The proper fix for this involves making
the overlap detection a bit smarter, but more importantly, detecting when overlaps
involve opaque items and avoiding batch breaks in these situations.

Fixes #35.