### PR TITLE
Un-normalize and round in the vertex shader instead of on the CPU.

### DIFF
--- a/res/blend.vs.glsl
+++ b/res/blend.vs.glsl
@@ -11,7 +11,7 @@ varying vec2 vMaskTexCoord;
 
 void main(void)
 {
-	vColorTexCoord = aColorTexCoord;
-	vMaskTexCoord = aMaskTexCoord;
+	vColorTexCoord = aColorTexCoord / 65535.0;
+	vMaskTexCoord = aMaskTexCoord / 65535.0;
     gl_Position = uTransform * vec4(aPosition, 1.0);
 }

--- a/res/border.vs.glsl
+++ b/res/border.vs.glsl
@@ -1,3 +1,5 @@
+#version 110
+
 attribute vec3 aPosition;
 attribute vec4 aColor;
 

--- a/res/debug.vs.glsl
+++ b/res/debug.vs.glsl
@@ -1,3 +1,5 @@
+#version 110
+
 attribute vec2 aPosition;
 attribute vec4 aColor;
 
@@ -7,6 +9,6 @@ varying vec4 vColor;
 
 void main(void)
 {
-	vColor = aColor;
+	vColor = aColor / 255.0;
     gl_Position = uTransform * vec4(aPosition, 0.0, 1.0);
 }

--- a/res/filter.vs.glsl
+++ b/res/filter.vs.glsl
@@ -11,7 +11,7 @@ varying vec2 vMaskTexCoord;
 
 void main(void)
 {
-	vColorTexCoord = aColorTexCoord;
-	vMaskTexCoord = aMaskTexCoord;
+	vColorTexCoord = aColorTexCoord / 65535.0;
+	vMaskTexCoord = aMaskTexCoord / 65535.0;
     gl_Position = uTransform * vec4(aPosition, 1.0);
 }

--- a/res/glyph.vs.glsl
+++ b/res/glyph.vs.glsl
@@ -13,8 +13,8 @@ varying vec2 vTexCoord;
 
 void main(void)
 {
-    vColor = aColor;
-    vTexCoord = aTexCoord;
+    vColor = aColor / 255.0;
+    vTexCoord = aTexCoord / 65535.0;
 
     mat4 matrix = uMatrixPalette[int(aMatrixIndex.x)];
     vec4 pos = matrix * vec4(aPosition, 1.0);

--- a/res/quad.vs.glsl
+++ b/res/quad.vs.glsl
@@ -8,7 +8,6 @@ attribute vec4 aMatrixIndex;
 
 uniform mat4 uTransform;
 uniform mat4 uMatrixPalette[32];
-uniform float uDevicePixelRatio;
 
 varying vec4 vColor;
 varying vec2 vColorTexCoord;
@@ -16,12 +15,12 @@ varying vec2 vMaskTexCoord;
 
 void main(void)
 {
-    vColor = aColor;
-    vColorTexCoord = aColorTexCoord;
-    vMaskTexCoord = aMaskTexCoord;
+    vColor = aColor / 255.0;
+    vColorTexCoord = aColorTexCoord / 65535.0;
+    vMaskTexCoord = aMaskTexCoord / 65535.0;
 
     mat4 matrix = uMatrixPalette[int(aMatrixIndex.x)];
     vec4 pos = matrix * vec4(aPosition, 1.0);
-    pos.xy = floor(pos.xy * uDevicePixelRatio + 0.5) / uDevicePixelRatio;
+    pos.xy = floor(pos.xy + 0.5);
     gl_Position = uTransform * pos;
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -615,11 +615,36 @@ impl Device {
             gl::enable_vertex_attrib_array(VertexAttribute::MaskTexCoord as gl::GLuint);
             gl::enable_vertex_attrib_array(VertexAttribute::MatrixIndex as gl::GLuint);
 
-            gl::vertex_attrib_pointer(VertexAttribute::Position as gl::GLuint, 2, gl::FLOAT, false, vertex_stride, 0);
-            gl::vertex_attrib_pointer(VertexAttribute::Color as gl::GLuint, 4, gl::UNSIGNED_BYTE, true, vertex_stride, 8);
-            gl::vertex_attrib_pointer(VertexAttribute::ColorTexCoord as gl::GLuint, 2, gl::UNSIGNED_SHORT, true, vertex_stride, 12);
-            gl::vertex_attrib_pointer(VertexAttribute::MaskTexCoord as gl::GLuint, 2, gl::UNSIGNED_SHORT, true, vertex_stride, 16);
-            gl::vertex_attrib_pointer(VertexAttribute::MatrixIndex as gl::GLuint, 4, gl::UNSIGNED_BYTE, false, vertex_stride, 20);
+            gl::vertex_attrib_pointer(VertexAttribute::Position as gl::GLuint,
+                                      2,
+                                      gl::FLOAT,
+                                      false,
+                                      vertex_stride,
+                                      0);
+            gl::vertex_attrib_pointer(VertexAttribute::Color as gl::GLuint,
+                                      4,
+                                      gl::UNSIGNED_BYTE,
+                                      false,
+                                      vertex_stride,
+                                      8);
+            gl::vertex_attrib_pointer(VertexAttribute::ColorTexCoord as gl::GLuint,
+                                      2,
+                                      gl::UNSIGNED_SHORT,
+                                      false,
+                                      vertex_stride,
+                                      12);
+            gl::vertex_attrib_pointer(VertexAttribute::MaskTexCoord as gl::GLuint,
+                                      2,
+                                      gl::UNSIGNED_SHORT,
+                                      false,
+                                      vertex_stride,
+                                      16);
+            gl::vertex_attrib_pointer(VertexAttribute::MatrixIndex as gl::GLuint,
+                                      4,
+                                      gl::UNSIGNED_BYTE,
+                                      false,
+                                      vertex_stride,
+                                      20);
         }
     }
 

--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -61,10 +61,10 @@ pub struct PackedColor {
 impl PackedColor {
     pub fn from_color(color: &ColorF) -> PackedColor {
         PackedColor {
-            r: (color.r * COLOR_FLOAT_TO_FIXED).round() as u8,
-            g: (color.g * COLOR_FLOAT_TO_FIXED).round() as u8,
-            b: (color.b * COLOR_FLOAT_TO_FIXED).round() as u8,
-            a: (color.a * COLOR_FLOAT_TO_FIXED).round() as u8,
+            r: (color.r * COLOR_FLOAT_TO_FIXED) as u8,
+            g: (color.g * COLOR_FLOAT_TO_FIXED) as u8,
+            b: (color.b * COLOR_FLOAT_TO_FIXED) as u8,
+            a: (color.a * COLOR_FLOAT_TO_FIXED) as u8,
         }
     }
 }
@@ -145,10 +145,10 @@ impl PackedVertex {
             x: x,
             y: y,
             color: PackedColor::from_color(color),
-            u: (u * UV_FLOAT_TO_FIXED).round() as u16,
-            v: (v * UV_FLOAT_TO_FIXED).round() as u16,
-            mu: (mu * UV_FLOAT_TO_FIXED).round() as u16,
-            mv: (mv * UV_FLOAT_TO_FIXED).round() as u16,
+            u: (u * UV_FLOAT_TO_FIXED) as u16,
+            v: (v * UV_FLOAT_TO_FIXED) as u16,
+            mu: (mu * UV_FLOAT_TO_FIXED) as u16,
+            mv: (mv * UV_FLOAT_TO_FIXED) as u16,
             matrix_index: 0,
             unused0: 0,
             unused1: 0,


### PR DESCRIPTION
Cuts out 20% of the profile on the site I was testing with.