### PR TITLE
Add support for rendering masks to RGBA8 textures.

### DIFF
--- a/src/resource_list.rs
+++ b/src/resource_list.rs
@@ -7,7 +7,7 @@ use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::hash_state::DefaultState;
 use string_cache::Atom;
 use types::{BorderRadiusRasterOp, BoxShadowCornerRasterOp};
-use types::{Glyph, ImageID, RasterItem};
+use types::{Glyph, ImageFormat, ImageID, RasterItem};
 
 type RequiredImageSet = HashSet<ImageID, DefaultState<FnvHasher>>;
 type RequiredGlyphMap = HashMap<Atom, HashSet<Glyph>, DefaultState<FnvHasher>>;
@@ -48,10 +48,12 @@ impl ResourceList {
     pub fn add_radius_raster(&mut self,
                              outer_radius: &Size2D<f32>,
                              inner_radius: &Size2D<f32>,
-                             inverted: bool) {
+                             inverted: bool,
+                             image_format: ImageFormat) {
         if let Some(raster_item) = BorderRadiusRasterOp::create(outer_radius,
                                                                 inner_radius,
-                                                                inverted) {
+                                                                inverted,
+                                                                image_format) {
             self.required_rasters.insert(RasterItem::BorderRadius(raster_item));
         }
     }

--- a/src/texture_cache.rs
+++ b/src/texture_cache.rs
@@ -176,7 +176,7 @@ impl TextureCache {
             if width <= level.size && height <= level.size {
                 let (page_list, mode) = match format {
                     ImageFormat::A8 => (&mut level.pages_a8, RenderTargetMode::RenderTarget),
-                    ImageFormat::RGBA8 => (&mut level.pages_rgba8, RenderTargetMode::None),
+                    ImageFormat::RGBA8 => (&mut level.pages_rgba8, RenderTargetMode::RenderTarget),
                     ImageFormat::RGB8 => (&mut level.pages_rgb8, RenderTargetMode::None),
                     ImageFormat::Invalid => unreachable!(),
                 };
@@ -252,7 +252,7 @@ impl TextureCache {
                                                0,
                                                width,
                                                height,
-                                               ImageFormat::A8);
+                                               op.image_format);
 
                 assert!(allocation.kind == AllocationKind::TexturePage);        // TODO: Handle large border radii not fitting in texture cache page
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,7 +6,7 @@ use string_cache::Atom;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NodeIndex(pub u32);
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ImageFormat {
     Invalid,
     A8,
@@ -347,10 +347,14 @@ pub struct BorderRadiusRasterOp {
     pub inner_radius_x: Au,
     pub inner_radius_y: Au,
     pub inverted: bool,
+    pub image_format: ImageFormat,
 }
 
 impl BorderRadiusRasterOp {
-    pub fn create(outer_radius: &Size2D<f32>, inner_radius: &Size2D<f32>, inverted: bool)
+    pub fn create(outer_radius: &Size2D<f32>,
+                  inner_radius: &Size2D<f32>,
+                  inverted: bool,
+                  image_format: ImageFormat)
                   -> Option<BorderRadiusRasterOp> {
         if outer_radius.width > 0.0 || outer_radius.height > 0.0 {
             Some(BorderRadiusRasterOp {
@@ -359,6 +363,7 @@ impl BorderRadiusRasterOp {
                 inner_radius_x: Au::from_f32_px(inner_radius.width),
                 inner_radius_y: Au::from_f32_px(inner_radius.height),
                 inverted: inverted,
+                image_format: image_format,
             })
         } else {
             None


### PR DESCRIPTION
This allows dotted borders to use color for the rounded edge, so clipping can use the mask texture.