### PR TITLE
Add a simple dead/live style free-list, and use this for texture cache items.

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -40,6 +40,10 @@ impl TextureId {
         let TextureId(id) = *self;
         gl::bind_texture(target.to_gl(), id);
     }
+
+    pub fn invalid() -> TextureId {
+        TextureId(0)
+    }
 }
 
 impl ProgramId {

--- a/src/freelist.rs
+++ b/src/freelist.rs
@@ -1,0 +1,70 @@
+#[derive(Debug, Copy, Clone)]
+pub struct FreeListItemId(u32);
+
+impl FreeListItemId {
+	#[inline]
+	pub fn new(value: u32) -> FreeListItemId {
+		FreeListItemId(value)
+	}
+
+	#[inline]
+	pub fn value(&self) -> u32 {
+		let FreeListItemId(value) = *self;
+		value
+	}
+}
+
+pub trait FreeListItem {
+	fn next_free_id(&self) -> Option<FreeListItemId>;
+	fn set_next_free_id(&mut self, id: Option<FreeListItemId>);
+}
+
+pub struct FreeList<T> {
+	items: Vec<T>,
+	first_free_index: Option<FreeListItemId>,
+}
+
+impl<T: FreeListItem> FreeList<T> {
+	pub fn new() -> FreeList<T> {
+		FreeList {
+			items: Vec::new(),
+			first_free_index: None,
+		}
+	}
+
+	pub fn insert(&mut self, item: T) -> FreeListItemId {
+		match self.first_free_index {
+			Some(free_index) => {
+				let FreeListItemId(index) = free_index;
+				let free_item = &mut self.items[index as usize];
+				self.first_free_index = free_item.next_free_id();
+				*free_item = item;
+				free_index
+			}
+			None => {
+				let item_id = FreeListItemId(self.items.len() as u32);
+				self.items.push(item);
+				item_id
+			}
+		}
+	}
+
+    pub fn get(&self, id: FreeListItemId) -> &T {
+        let FreeListItemId(index) = id;
+        &self.items[index as usize]
+    }
+
+    pub fn get_mut(&mut self, id: FreeListItemId) -> &mut T {
+        let FreeListItemId(index) = id;
+        &mut self.items[index as usize]
+    }
+
+    // TODO(gw): Actually free items from the texture cache!!
+    #[allow(dead_code)]
+	pub fn free(&mut self, id: FreeListItemId) {
+		let FreeListItemId(index) = id;
+		let item = &mut self.items[index as usize];
+		item.set_next_free_id(self.first_free_index);
+		self.first_free_index = Some(id);
+	}
+}

--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -35,15 +35,6 @@ impl BatchId {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct ImageID(usize);
-
-impl ImageID {
-    pub fn new() -> ImageID {
-        ImageID(new_resource_id())
-    }
-}
-
 #[derive(Debug, PartialEq, Eq)]
 pub enum TextureSampler {
     Color,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ mod aabbtree;
 mod batch;
 mod clipper;
 mod device;
+mod freelist;
 mod internal_types;
 mod layer;
 mod optimizer;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -7,7 +7,7 @@ use gleam::gl;
 use internal_types::{ApiMsg, Frame, ResultMsg, TextureUpdateOp, BatchUpdateOp, BatchUpdateList};
 use internal_types::{TextureUpdateDetails, TextureUpdateList, PackedVertex, RenderTargetMode};
 use internal_types::{BatchId, ORTHO_NEAR_PLANE, ORTHO_FAR_PLANE, DrawCommandInfo};
-use internal_types::{ImageID, PackedVertexForTextureCacheUpdate, TextureTarget};
+use internal_types::{PackedVertexForTextureCacheUpdate, TextureTarget};
 use render_api::RenderApi;
 use render_backend::RenderBackend;
 use std::collections::HashMap;
@@ -121,7 +121,7 @@ impl Renderer {
             0xff, 0xff,
         ];
         // TODO: Ensure that the white texture can never get evicted when the cache supports LRU eviction!
-        let white_image_id = ImageID::new();
+        let white_image_id = texture_cache.new_item_id();
         texture_cache.insert(white_image_id,
                              0,
                              0,
@@ -130,7 +130,7 @@ impl Renderer {
                              ImageFormat::RGBA8,
                              TextureInsertOp::Blit(white_pixels));
 
-        let dummy_mask_image_id = ImageID::new();
+        let dummy_mask_image_id = texture_cache.new_item_id();
         texture_cache.insert(dummy_mask_image_id,
                              0,
                              0,

--- a/src/resource_cache.rs
+++ b/src/resource_cache.rs
@@ -1,13 +1,14 @@
 use fnv::FnvHasher;
-use internal_types::{FontTemplate, ImageID, ImageResource, GlyphKey, RasterItem};
+use internal_types::{FontTemplate, ImageResource, GlyphKey, RasterItem};
 use std::collections::HashMap;
 use std::collections::hash_state::DefaultState;
+use texture_cache::TextureCacheItemId;
 use types::{FontKey, ImageKey};
 
 pub struct ResourceCache {
-    cached_glyphs: HashMap<GlyphKey, ImageID, DefaultState<FnvHasher>>,
-    cached_rasters: HashMap<RasterItem, ImageID, DefaultState<FnvHasher>>,
-    cached_images: HashMap<ImageKey, ImageID, DefaultState<FnvHasher>>,
+    cached_glyphs: HashMap<GlyphKey, TextureCacheItemId, DefaultState<FnvHasher>>,
+    cached_rasters: HashMap<RasterItem, TextureCacheItemId, DefaultState<FnvHasher>>,
+    cached_images: HashMap<ImageKey, TextureCacheItemId, DefaultState<FnvHasher>>,
 
     font_templates: HashMap<FontKey, FontTemplate, DefaultState<FnvHasher>>,
     image_templates: HashMap<ImageKey, ImageResource, DefaultState<FnvHasher>>,
@@ -42,7 +43,7 @@ impl ResourceCache {
 
     pub fn cache_raster_if_required<F>(&mut self,
                                        raster_item: &RasterItem,
-                                       mut f: F) where F: FnMut() -> ImageID {
+                                       mut f: F) where F: FnMut() -> TextureCacheItemId {
         if !self.cached_rasters.contains_key(raster_item) {
             let image_id = f();
             self.cached_rasters.insert(raster_item.clone(), image_id);
@@ -51,7 +52,7 @@ impl ResourceCache {
 
     pub fn cache_glyph_if_required<F>(&mut self,
                                       glyph_key: &GlyphKey,
-                                      mut f: F) where F: FnMut() -> ImageID {
+                                      mut f: F) where F: FnMut() -> TextureCacheItemId {
         if !self.cached_glyphs.contains_key(glyph_key) {
             let image_id = f();
             self.cached_glyphs.insert(glyph_key.clone(), image_id);
@@ -60,7 +61,7 @@ impl ResourceCache {
 
     pub fn cache_image_if_required<F>(&mut self,
                                       image_key: ImageKey,
-                                      mut f: F) where F: FnMut(&ImageResource) -> ImageID {
+                                      mut f: F) where F: FnMut(&ImageResource) -> TextureCacheItemId {
         if !self.cached_images.contains_key(&image_key) {
             let image_id = {
                 let image_template = self.get_image_template(image_key);
@@ -70,15 +71,15 @@ impl ResourceCache {
         }
     }
 
-    pub fn get_glyph(&self, glyph_key: &GlyphKey) -> ImageID {
+    pub fn get_glyph(&self, glyph_key: &GlyphKey) -> TextureCacheItemId {
         self.cached_glyphs[glyph_key]
     }
 
-    pub fn get_raster(&self, raster_item: &RasterItem) -> ImageID {
+    pub fn get_raster(&self, raster_item: &RasterItem) -> TextureCacheItemId {
         self.cached_rasters[raster_item]
     }
 
-    pub fn get_image(&self, image_key: ImageKey) -> ImageID {
+    pub fn get_image(&self, image_key: ImageKey) -> TextureCacheItemId {
         self.cached_images[&image_key]
     }
 }


### PR DESCRIPTION
This removes all hashing overhead from the texture cache.