### PR TITLE
Optimize large tiled backgrounds by prerendering a few repeats into the texture cache.

### DIFF
--- a/res/tile.fs.glsl
+++ b/res/tile.fs.glsl
@@ -1,0 +1,8 @@
+void main(void) {
+    vec2 textureSize = vBorderPosition.zw - vBorderPosition.xy;
+    vec3 colorTexCoord = vec3(vBorderPosition.xy + mod(vColorTexCoord.xy, 1.0) * textureSize,
+                              vColorTexCoord.z);
+    vec4 diffuse = Texture(sDiffuse, colorTexCoord);
+    SetFragColor(diffuse);
+}
+

--- a/res/tile.vs.glsl
+++ b/res/tile.vs.glsl
@@ -1,0 +1,7 @@
+void main(void)
+{
+	vColorTexCoord = vec3(aBorderRadii.xy, aMisc.y);
+    vBorderPosition = aBorderPosition;
+    gl_Position = uTransform * vec4(aPosition, 1.0);
+}
+

--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -204,6 +204,8 @@ pub enum TextureUpdateDetails {
     BorderRadius(Au, Au, Au, Au, bool),
     /// Blur radius border radius, and whether inverted, respectively.
     BoxShadowCorner(Au, Au, bool),
+    /// Bytes, stretch size, and scratch texture image, respectively.
+    Tile(Vec<u8>, Size2D<u32>, TextureImage),
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -728,5 +730,14 @@ impl GlyphKey {
 pub enum RasterItem {
     BorderRadius(BorderRadiusRasterOp),
     BoxShadowCorner(BoxShadowCornerRasterOp),
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub struct TiledImageKey {
+    pub image_key: ImageKey,
+    pub tiled_width: u32,
+    pub tiled_height: u32,
+    pub stretch_width: u32,
+    pub stretch_height: u32,
 }
 


### PR DESCRIPTION
Timings:

* Page with nothing but a 1x1 tiled background — 100. ms → 0.423 ms
  (236x improvement)

* https://miiverse.nintendo.net/guide/ — 3.11 ms → 2.12 ms (47%
  improvement)

* http://en.wikipedia.org/wiki/Servomechanism — 0.951 ms → 0.842 ms
  (13% improvement)