### PR TITLE
Move texture cache inside the resource cache.

### DIFF
--- a/src/resource_cache.rs
+++ b/src/resource_cache.rs
@@ -1,9 +1,31 @@
+use app_units::Au;
+use device::{TextureId};
+use euclid::Size2D;
 use fnv::FnvHasher;
 use internal_types::{FontTemplate, ImageResource, GlyphKey, RasterItem, TiledImageKey};
+use internal_types::{TextureTarget, TextureUpdateList};
+use platform::font::{FontContext, RasterizedGlyph};
+use renderer::BLUR_INFLATION_FACTOR;
+use resource_list::ResourceList;
+use scoped_threadpool;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::collections::hash_state::DefaultState;
-use texture_cache::TextureCacheItemId;
-use types::{FontKey, ImageKey};
+use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
+use std::sync::atomic::Ordering::SeqCst;
+use std::thread;
+use texture_cache::{TextureCache, TextureCacheItem, TextureCacheItemId, TextureInsertOp};
+use types::{FontKey, ImageKey, ImageFormat};
+
+static FONT_CONTEXT_COUNT: AtomicUsize = ATOMIC_USIZE_INIT;
+
+thread_local!(pub static FONT_CONTEXT: RefCell<FontContext> = RefCell::new(FontContext::new()));
+
+struct GlyphRasterJob {
+    image_id: TextureCacheItemId,
+    glyph_key: GlyphKey,
+    result: Option<RasterizedGlyph>,
+}
 
 pub struct ResourceCache {
     cached_glyphs: HashMap<GlyphKey, TextureCacheItemId, DefaultState<FnvHasher>>,
@@ -13,10 +35,37 @@ pub struct ResourceCache {
 
     font_templates: HashMap<FontKey, FontTemplate, DefaultState<FnvHasher>>,
     image_templates: HashMap<ImageKey, ImageResource, DefaultState<FnvHasher>>,
+    device_pixel_ratio: f32,
+
+    texture_cache: TextureCache,
+
+    pending_raster_jobs: Vec<GlyphRasterJob>,
+
+    white_image_id: TextureCacheItemId,
+    dummy_mask_image_id: TextureCacheItemId,
 }
 
 impl ResourceCache {
-    pub fn new() -> ResourceCache {
+    pub fn new(thread_pool: &mut scoped_threadpool::Pool,
+               texture_cache: TextureCache,
+               white_image_id: TextureCacheItemId,
+               dummy_mask_image_id: TextureCacheItemId,
+               device_pixel_ratio: f32) -> ResourceCache {
+
+        let thread_count = thread_pool.thread_count() as usize;
+        thread_pool.scoped(|scope| {
+            for _ in 0..thread_count {
+                scope.execute(|| {
+                    FONT_CONTEXT.with(|_| {
+                        FONT_CONTEXT_COUNT.fetch_add(1, SeqCst);
+                        while FONT_CONTEXT_COUNT.load(SeqCst) != thread_count {
+                            thread::sleep_ms(1);
+                        }
+                    });
+                });
+            }
+        });
+
         ResourceCache {
             cached_glyphs: HashMap::with_hash_state(Default::default()),
             cached_rasters: HashMap::with_hash_state(Default::default()),
@@ -24,6 +73,11 @@ impl ResourceCache {
             cached_tiled_images: HashMap::with_hash_state(Default::default()),
             font_templates: HashMap::with_hash_state(Default::default()),
             image_templates: HashMap::with_hash_state(Default::default()),
+            texture_cache: texture_cache,
+            pending_raster_jobs: Vec::new(),
+            device_pixel_ratio: device_pixel_ratio,
+            white_image_id: white_image_id,
+            dummy_mask_image_id: dummy_mask_image_id,
         }
     }
 
@@ -39,68 +93,191 @@ impl ResourceCache {
         self.image_templates.insert(image_key, resource);
     }
 
-    pub fn get_font_template(&self, font_key: FontKey) -> &FontTemplate {
-        &self.font_templates[&font_key]
+    pub fn add_resource_list(&mut self, resource_list: &ResourceList) {
+        // Update texture cache with any GPU generated procedural items.
+        resource_list.for_each_raster(|raster_item| {
+            if !self.cached_rasters.contains_key(raster_item) {
+                let image_id = self.texture_cache.new_item_id();
+                self.texture_cache.insert_raster_op(image_id, raster_item);
+                self.cached_rasters.insert(raster_item.clone(), image_id);
+            }
+        });
+
+        // Update texture cache with any images that aren't yet uploaded to GPU.
+        resource_list.for_each_image(|image_key| {
+            if !self.cached_images.contains_key(&image_key) {
+                let image_id = self.texture_cache.new_item_id();
+                let image_template = &self.image_templates[&image_key];
+                // TODO: Can we avoid the clone of the bytes here?
+                self.texture_cache.insert(image_id,
+                                     0,
+                                     0,
+                                     image_template.width,
+                                     image_template.height,
+                                     image_template.format,
+                                     TextureInsertOp::Blit(image_template.bytes.clone()));
+                self.cached_images.insert(image_key, image_id);
+            }
+        });
+
+        // Update texture cache with any new image tile operations.
+        resource_list.for_each_tiled_image(|tiled_image_key| {
+            if !self.cached_tiled_images.contains_key(&tiled_image_key) {
+                let image_id = self.texture_cache.new_item_id();
+                let image_template = &self.image_templates[&tiled_image_key.image_key];
+                // TODO: Can we avoid the clone of the bytes here?
+                let stretch_size = Size2D::new(tiled_image_key.stretch_width,
+                                               tiled_image_key.stretch_height);
+                self.texture_cache.insert(image_id,
+                                          0,
+                                          0,
+                                          tiled_image_key.tiled_width,
+                                          tiled_image_key.tiled_height,
+                                          image_template.format,
+                                          TextureInsertOp::Tile(
+                                              image_template.bytes.clone(),
+                                              stretch_size));
+                self.cached_tiled_images.insert((*tiled_image_key).clone(), image_id);
+            }
+        });
+
+        // Update texture cache with any newly rasterized glyphs.
+        resource_list.for_each_glyph(|glyph_key| {
+            if !self.cached_glyphs.contains_key(glyph_key) {
+                let image_id = self.texture_cache.new_item_id();
+                self.pending_raster_jobs.push(GlyphRasterJob {
+                    image_id: image_id,
+                    glyph_key: glyph_key.clone(),
+                    result: None,
+                });
+                self.cached_glyphs.insert(glyph_key.clone(), image_id);
+            }
+        });
     }
 
-    pub fn get_image_template(&self, key: ImageKey) -> &ImageResource {
-        &self.image_templates[&key]
-    }
+    pub fn raster_pending_glyphs(&mut self,
+                                 thread_pool: &mut scoped_threadpool::Pool) {
+        // Run raster jobs in parallel
+        run_raster_jobs(thread_pool,
+                        &mut self.pending_raster_jobs,
+                        &self.font_templates,
+                        self.device_pixel_ratio);
 
-    pub fn cache_raster_if_required<F>(&mut self,
-                                       raster_item: &RasterItem,
-                                       mut f: F) where F: FnMut() -> TextureCacheItemId {
-        if !self.cached_rasters.contains_key(raster_item) {
-            let image_id = f();
-            self.cached_rasters.insert(raster_item.clone(), image_id);
+        // Add completed raster jobs to the texture cache
+        for job in self.pending_raster_jobs.drain(..) {
+            let result = job.result.expect("Failed to rasterize the glyph?");
+            let texture_width;
+            let texture_height;
+            let insert_op;
+            match job.glyph_key.blur_radius {
+                Au(0) => {
+                    texture_width = result.width;
+                    texture_height = result.height;
+                    insert_op = TextureInsertOp::Blit(result.bytes);
+                }
+                blur_radius => {
+                    let blur_radius_px = f32::ceil(blur_radius.to_f32_px() * self.device_pixel_ratio)
+                        as u32;
+                    texture_width = result.width + blur_radius_px * BLUR_INFLATION_FACTOR;
+                    texture_height = result.height + blur_radius_px * BLUR_INFLATION_FACTOR;
+                    insert_op = TextureInsertOp::Blur(result.bytes,
+                                                      Size2D::new(result.width, result.height),
+                                                      blur_radius);
+                }
+            }
+            self.texture_cache.insert(job.image_id,
+                                      result.left,
+                                      result.top,
+                                      texture_width,
+                                      texture_height,
+                                      ImageFormat::RGBA8,
+                                      insert_op);
         }
     }
 
-    pub fn cache_glyph_if_required<F>(&mut self,
-                                      glyph_key: &GlyphKey,
-                                      mut f: F) where F: FnMut() -> TextureCacheItemId {
-        if !self.cached_glyphs.contains_key(glyph_key) {
-            let image_id = f();
-            self.cached_glyphs.insert(glyph_key.clone(), image_id);
+    pub fn allocate_render_target(&mut self,
+                                  target: TextureTarget,
+                                  width: u32,
+                                  height: u32,
+                                  levels: u32,
+                                  format: ImageFormat)
+                                  -> TextureId {
+        self.texture_cache.allocate_render_target(target,
+                                                  width,
+                                                  height,
+                                                  levels,
+                                                  format)
+    }
+
+    pub fn free_render_target(&mut self, texture_id: TextureId) {
+        self.texture_cache.free_render_target(texture_id)
+    }
+
+    pub fn pending_updates(&mut self) -> TextureUpdateList {
+        self.texture_cache.pending_updates()
+    }
+
+    #[inline]
+    pub fn get_dummy_mask_image(&self) -> &TextureCacheItem {
+        self.texture_cache.get(self.dummy_mask_image_id)
+    }
+
+    #[inline]
+    pub fn get_dummy_color_image(&self) -> &TextureCacheItem {
+        self.texture_cache.get(self.white_image_id)
+    }
+
+    #[inline]
+    pub fn get_glyph(&self, glyph_key: &GlyphKey) -> &TextureCacheItem {
+        let image_id = self.cached_glyphs[glyph_key];
+        self.texture_cache.get(image_id)
+    }
+
+    #[inline]
+    pub fn get_image(&self, image_key: ImageKey) -> &TextureCacheItem {
+        let image_id = self.cached_images[&image_key];
+        self.texture_cache.get(image_id)
+    }
+
+    #[inline]
+    pub fn get_tiled_image(&self, tiled_image_key: &TiledImageKey) -> &TextureCacheItem {
+        let image_id = self.cached_tiled_images[tiled_image_key];
+        self.texture_cache.get(image_id)
+    }
+
+    #[inline]
+    pub fn get_raster(&self, raster_item: &RasterItem) -> &TextureCacheItem {
+        let image_id = self.cached_rasters[raster_item];
+        self.texture_cache.get(image_id)
+    }
+}
+
+fn run_raster_jobs(thread_pool: &mut scoped_threadpool::Pool,
+                   pending_raster_jobs: &mut Vec<GlyphRasterJob>,
+                   font_templates: &HashMap<FontKey, FontTemplate, DefaultState<FnvHasher>>,
+                   device_pixel_ratio: f32) {
+    // Run raster jobs in parallel
+    thread_pool.scoped(|scope| {
+        for job in pending_raster_jobs {
+            scope.execute(|| {
+                let font_template = &font_templates[&job.glyph_key.font_key];
+                FONT_CONTEXT.with(move |font_context| {
+                    let mut font_context = font_context.borrow_mut();
+                    match *font_template {
+                        FontTemplate::Raw(ref bytes) => {
+                            font_context.add_raw_font(&job.glyph_key.font_key, &**bytes);
+                        }
+                        FontTemplate::Native(ref native_font_handle) => {
+                            font_context.add_native_font(&job.glyph_key.font_key,
+                                                         (*native_font_handle).clone());
+                        }
+                    }
+                    job.result = font_context.get_glyph(job.glyph_key.font_key,
+                                                        job.glyph_key.size,
+                                                        job.glyph_key.index,
+                                                        device_pixel_ratio);
+                });
+            });
         }
-    }
-
-    pub fn cache_image_if_required<F>(&mut self,
-                                      image_key: ImageKey,
-                                      mut f: F) where F: FnMut(&ImageResource) -> TextureCacheItemId {
-        if !self.cached_images.contains_key(&image_key) {
-            let image_id = {
-                let image_template = self.get_image_template(image_key);
-                f(image_template)
-            };
-            self.cached_images.insert(image_key, image_id);
-        }
-    }
-
-    pub fn cache_tiled_image_if_required<F>(&mut self, tiled_image_key: &TiledImageKey, mut f: F)
-                                            where F: FnMut(&ImageResource) -> TextureCacheItemId {
-        if !self.cached_tiled_images.contains_key(&tiled_image_key) {
-            let image_id = {
-                let image_template = self.get_image_template(tiled_image_key.image_key);
-                f(image_template)
-            };
-            self.cached_tiled_images.insert((*tiled_image_key).clone(), image_id);
-        }
-    }
-
-    pub fn get_glyph(&self, glyph_key: &GlyphKey) -> TextureCacheItemId {
-        self.cached_glyphs[glyph_key]
-    }
-
-    pub fn get_raster(&self, raster_item: &RasterItem) -> TextureCacheItemId {
-        self.cached_rasters[raster_item]
-    }
-
-    pub fn get_image(&self, image_key: ImageKey) -> TextureCacheItemId {
-        self.cached_images[&image_key]
-    }
-
-    pub fn get_tiled_image(&self, tiled_image_key: &TiledImageKey) -> TextureCacheItemId {
-        self.cached_tiled_images[tiled_image_key]
-    }
+    });
 }


### PR DESCRIPTION
This is prep work for support texture cache updates and frees, in particular for canvas animation.

This also tidies up quite a bit of the code, reducing number of params in function calls.