### PR TITLE
Reuse batches across paints on a per-node basis.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde_macros = "0.5"
 fnv="*"
 scoped_threadpool = "0.1.6"
 app_units = "0.1"
+log = "*"
 simd = { git = "https://github.com/huonw/simd" }
 
 [target.x86_64-apple-darwin.dependencies]

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,7 +1,8 @@
 use aabbtree::AABBTree;
 use euclid::{Point2D, Rect, Size2D};
 use internal_types::{BatchUpdate, BatchUpdateList, BatchUpdateOp};
-use types::NodeIndex;
+use render_backend::FlatDrawList;
+use types::{DrawList, NodeIndex};
 
 pub struct Layer {
     // TODO: Remove pub from here if possible in the future
@@ -48,8 +49,13 @@ impl Layer {
         self.aabb_tree.cull(&adjusted_viewport);
     }
 
-    pub fn take_compiled_data_from(&mut self, other_layer: &mut Layer) {
-        self.aabb_tree.take_compiled_data_from(&mut other_layer.aabb_tree)
+    pub fn reuse_compiled_data_from_old_layer_if_possible(&mut self,
+                                                          other_layer: &mut Layer,
+                                                          these_draw_lists: &Vec<FlatDrawList>,
+                                                          old_draw_lists: &Vec<DrawList>) {
+        self.aabb_tree.reuse_compiled_data_from_old_tree_if_possible(&mut other_layer.aabb_tree,
+                                                                     these_draw_lists,
+                                                                     old_draw_lists)
     }
 
     #[allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@
 #![feature(hashmap_hasher)]
 #![feature(vec_push_all)]
 
+#[macro_use]
+extern crate log;
+
 extern crate app_units;
 extern crate euclid;
 extern crate fnv;

--- a/src/types.rs
+++ b/src/types.rs
@@ -315,6 +315,12 @@ pub struct DisplayItem {
     pub node_index: Option<NodeIndex>,
 }
 
+impl DisplayItem {
+    pub fn is_identical_to(&self, other: &DisplayItem) -> bool {
+        self.item == other.item && self.rect == other.rect && self.clip == other.clip
+    }
+}
+
 pub enum DisplayListMode {
     Default,
     PseudoFloat,


### PR DESCRIPTION
This didn't really improve performance from what I saw, but it's a
cleaner and more general optimization than the one we had previously,
which only reused batches if the entire display list didn't change. In
any case, it's a precursor to more aggressive optimizations we could do
to reuse portions of batches within AABB tree nodes.