### PR TITLE
 	Unify clip rects and clip regions into a single "combined clip region" structure, and clip inset box shadows to rounded rectangle corners.

### DIFF
--- a/res/box_shadow.fs.glsl
+++ b/res/box_shadow.fs.glsl
@@ -16,18 +16,26 @@ void main(void)
     float sigma = vBlurRadius / 2.0;
     float sigmaSqrt2 = sigma * 1.41421356237;
 
+    float length;
+    float value;
     vec2 position = vPosition - vBorderPosition.zw;
-    vec2 arcCenter = vDestTextureSize;
-    float arcRadius = vBorderRadii.x;
-    float distance = distance(position, vec2(arcCenter));
-    float value = clamp(distance, arcRadius - vBlurRadius, arcRadius + vBlurRadius);
-    float minValue = min(value - range, arcRadius) - value;
-    float maxValue = min(value + range, arcRadius) - value;
+    if (vBorderRadii.y == 0.0) {
+        length = range;
+        value = position.x;
+    } else {
+        length = vBorderRadii.x;
+        vec2 center = vec2(max(position.x - range, length),
+                           max(position.y - range, length));
+        value = distance(position - range, center);
+    }
+
+    float minValue = min(value - range, length) - value;
+    float maxValue = min(value + range, length) - value;
     if (minValue < maxValue) {
         value = 1.0 - 0.5 * (erf(maxValue / sigmaSqrt2) - erf(minValue / sigmaSqrt2));
     } else {
-        value = 0.0;
+        value = 1.0;
     }
-    SetFragColor(vColor - vec4(value));
+    SetFragColor(vec4(vColor.rgb, vColor.a == 0.0 ? value : 1.0 - value));
 }
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -67,7 +67,7 @@ pub struct Renderer {
     u_filter_params: UniformLocation,
     u_filter_texture_size: UniformLocation,
 
-    shadow_corner_program_id: ProgramId,
+    box_shadow_program_id: ProgramId,
 
     blur_program_id: ProgramId,
     u_direction: UniformLocation,
@@ -94,8 +94,8 @@ impl Renderer {
         let border_program_id = device.create_program("border.vs.glsl", "border.fs.glsl");
         let blend_program_id = device.create_program("blend.vs.glsl", "blend.fs.glsl");
         let filter_program_id = device.create_program("filter.vs.glsl", "filter.fs.glsl");
-        let shadow_corner_program_id = device.create_program("shadow_corner.vs.glsl",
-                                                             "shadow_corner.fs.glsl");
+        let box_shadow_program_id = device.create_program("box_shadow.vs.glsl",
+                                                          "box_shadow.fs.glsl");
         let blur_program_id = device.create_program("blur.vs.glsl", "blur.fs.glsl");
         let tile_program_id = device.create_program("tile.vs.glsl", "tile.fs.glsl");
 
@@ -170,7 +170,7 @@ impl Renderer {
             filter_program_id: filter_program_id,
             quad_program_id: quad_program_id,
             blit_program_id: blit_program_id,
-            shadow_corner_program_id: shadow_corner_program_id,
+            box_shadow_program_id: box_shadow_program_id,
             blur_program_id: blur_program_id,
             tile_program_id: tile_program_id,
             u_blend_params: u_blend_params,
@@ -486,7 +486,7 @@ impl Renderer {
 
                                 let border_program_id = self.border_program_id;
                                 let color = if inverted {
-                                    ColorF::new(0.0, 0.0, 0.0, 0.0)
+                                    ColorF::new(0.0, 0.0, 0.0, 1.0)
                                 } else {
                                     ColorF::new(1.0, 1.0, 1.0, 1.0)
                                 };
@@ -660,12 +660,12 @@ impl Renderer {
                                            blur_radius: Au,
                                            box_shadow_part: BoxShadowPart,
                                            inverted: bool) {
-        let shadow_corner_program_id = self.shadow_corner_program_id;
+        let box_shadow_program_id = self.box_shadow_program_id;
 
         let blur_radius = blur_radius.to_f32_px();
 
         let color = if inverted {
-            ColorF::new(0.0, 0.0, 0.0, 0.0)
+            ColorF::new(1.0, 1.0, 1.0, 0.0)
         } else {
             ColorF::new(1.0, 1.0, 1.0, 1.0)
         };
@@ -730,7 +730,7 @@ impl Renderer {
         let mut batch = self.get_or_create_raster_batch(update_id,
                                                         update_index,
                                                         TextureId(0),
-                                                        shadow_corner_program_id,
+                                                        box_shadow_program_id,
                                                         None);
         batch.add_draw_item(update_id, TextureId(0), &vertices);
     }

--- a/src/resource_list.rs
+++ b/src/resource_list.rs
@@ -6,7 +6,7 @@ use internal_types::{Glyph, GlyphKey, RasterItem, TiledImageKey};
 use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::hash_state::DefaultState;
-use types::{FontKey, ImageFormat, ImageKey};
+use types::{BorderRadius, FontKey, ImageFormat, ImageKey};
 
 type RequiredImageSet = HashSet<ImageKey, DefaultState<FnvHasher>>;
 type RequiredGlyphMap = HashMap<FontKey, HashSet<Glyph>, DefaultState<FnvHasher>>;
@@ -73,6 +73,14 @@ impl ResourceList {
                                                                 image_format) {
             self.required_rasters.insert(RasterItem::BorderRadius(raster_item));
         }
+    }
+
+    pub fn add_radius_raster_for_border_radii(&mut self, radii: &BorderRadius) {
+        let zero_size = Size2D::new(0.0, 0.0);
+        self.add_radius_raster(&radii.top_left, &zero_size, false, ImageFormat::A8);
+        self.add_radius_raster(&radii.top_right, &zero_size, false, ImageFormat::A8);
+        self.add_radius_raster(&radii.bottom_left, &zero_size, false, ImageFormat::A8);
+        self.add_radius_raster(&radii.bottom_right, &zero_size, false, ImageFormat::A8);
     }
 
     pub fn add_box_shadow_corner(&mut self, blur_radius: f32, border_radius: f32, inverted: bool) {

--- a/src/texture_cache.rs
+++ b/src/texture_cache.rs
@@ -501,7 +501,7 @@ impl TextureCache {
                                                0,
                                                op.raster_size.to_nearest_px() as u32,
                                                op.raster_size.to_nearest_px() as u32,
-                                               ImageFormat::A8,
+                                               ImageFormat::RGBA8,
                                                false);
 
                 // TODO(pcwalton): Handle large box shadows not fitting in texture cache page.

--- a/src/types.rs
+++ b/src/types.rs
@@ -131,6 +131,26 @@ pub struct BorderRadius {
     pub bottom_right: Size2D<f32>,
 }
 
+impl BorderRadius {
+    pub fn zero() -> BorderRadius {
+        BorderRadius {
+            top_left: Size2D::new(0.0, 0.0),
+            top_right: Size2D::new(0.0, 0.0),
+            bottom_left: Size2D::new(0.0, 0.0),
+            bottom_right: Size2D::new(0.0, 0.0),
+        }
+    }
+
+    pub fn uniform(radius: f32) -> BorderRadius {
+        BorderRadius {
+            top_left: Size2D::new(radius, radius),
+            top_right: Size2D::new(radius, radius),
+            bottom_left: Size2D::new(radius, radius),
+            bottom_right: Size2D::new(radius, radius),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum BorderStyle {
     None,
@@ -615,7 +635,7 @@ impl ClipRegion {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ComplexClipRegion {
     /// The boundaries of the rectangle.
     pub rect: Rect<f32>,
@@ -628,6 +648,13 @@ impl ComplexClipRegion {
         ComplexClipRegion {
             rect: rect,
             radii: radii,
+        }
+    }
+
+    pub fn from_rect(rect: &Rect<f32>) -> ComplexClipRegion {
+        ComplexClipRegion {
+            rect: *rect,
+            radii: BorderRadius::zero(),
         }
     }
 }


### PR DESCRIPTION
This necessitated changing box shadows to RGBA, because we can't use two
mask textures. An alternate solution for the future would be have a
"mask combiner" path that can combine two masks as a raster op, but this
is more complex.

This also fixes the box shadow fragment shader, as noted in the first commit.