### PR TITLE
Implement better scan and split strategies for the atlas allocator, and use as large of a texture as the hardware allows.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ time = "*"
 fnv="*"
 scoped_threadpool = "0.1.6"
 app_units = "0.1"
+lazy_static = "0.1"
 simd = { git = "https://github.com/huonw/simd" }
 
 [target.x86_64-apple-darwin.dependencies]

--- a/src/device.rs
+++ b/src/device.rs
@@ -35,6 +35,14 @@ static VERTEX_SHADER_PREAMBLE: &'static str = "es2_common.vs.glsl";
 #[cfg(not(any(target_os = "android", target_os = "gonk")))]
 static VERTEX_SHADER_PREAMBLE: &'static str = "gl3_common.vs.glsl";
 
+lazy_static! {
+    pub static ref MAX_TEXTURE_SIZE: gl::GLint = {
+        let mut value = 0;
+        gl::get_integer_v(gl::MAX_TEXTURE_SIZE, &mut value);
+        value
+    };
+}
+
 impl TextureId {
     fn bind(&self, target: TextureTarget) {
         let TextureId(id) = *self;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
 #![feature(vec_push_all)]
 #![feature(step_by, convert, zero_one)]
 
+#[macro_use]
+extern crate lazy_static;
+
 mod aabbtree;
 mod batch;
 mod batch_builder;


### PR DESCRIPTION
The texture atlas allocator now uses the Best Area Fit and Max/Min Area
Split Rules to make decisions. These were the optimum strategies for the
guillotine algorithm in "A Thousand Ways to Pack the Bin":

    http://clb.demon.fi/files/RectangleBinPack.pdf

Seems to result in much decreased texture atlas fragmentation.