### PR TITLE
Fix alpha blending for `opacity`.

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,3 +1,4 @@
+use app_units::Au;
 use batch::MAX_MATRICES_PER_BATCH;
 use device::{TextureId};
 use euclid::{Rect, Point2D, Size2D, Matrix4};
@@ -6,7 +7,7 @@ use internal_types::{BlurDirection, LowLevelFilterOp, CompositionOp, DrawListIte
 use internal_types::{BatchUpdateList, DrawListId, TextureTarget};
 use internal_types::{RendererFrame, DrawListContext, BatchInfo, DrawCall};
 use internal_types::{BatchUpdate, BatchUpdateOp, DrawLayer};
-use internal_types::{DrawCommand, ClearInfo, CompositeInfo};
+use internal_types::{DrawCommand, ClearInfo, CompositeInfo, ANGLE_FLOAT_TO_FIXED};
 use layer::Layer;
 use node_compiler::NodeCompiler;
 use resource_cache::ResourceCache;
@@ -425,36 +426,37 @@ impl Frame {
                             BlurDirection::Vertical)));
                     }
                     FilterOp::Brightness(amount) => {
-                        composition_operations.push(CompositionOp::Filter(LowLevelFilterOp::Brightness(
-                            amount)));
+                        composition_operations.push(CompositionOp::Filter(
+                                LowLevelFilterOp::Brightness(Au::from_f32_px(amount))));
                     }
                     FilterOp::Contrast(amount) => {
-                        composition_operations.push(CompositionOp::Filter(LowLevelFilterOp::Contrast(
-                            amount)));
+                        composition_operations.push(CompositionOp::Filter(
+                                LowLevelFilterOp::Contrast(Au::from_f32_px(amount))));
                     }
                     FilterOp::Grayscale(amount) => {
-                        composition_operations.push(CompositionOp::Filter(LowLevelFilterOp::Grayscale(
-                            amount)));
+                        composition_operations.push(CompositionOp::Filter(
+                                LowLevelFilterOp::Grayscale(Au::from_f32_px(amount))));
                     }
                     FilterOp::HueRotate(angle) => {
-                        composition_operations.push(CompositionOp::Filter(LowLevelFilterOp::HueRotate(
-                            angle)));
+                        composition_operations.push(CompositionOp::Filter(
+                                LowLevelFilterOp::HueRotate(f32::round(
+                                        angle * ANGLE_FLOAT_TO_FIXED) as i32)));
                     }
                     FilterOp::Invert(amount) => {
-                        composition_operations.push(CompositionOp::Filter(LowLevelFilterOp::Invert(
-                            amount)));
+                        composition_operations.push(CompositionOp::Filter(
+                                LowLevelFilterOp::Invert(Au::from_f32_px(amount))));
                     }
                     FilterOp::Opacity(amount) => {
-                        composition_operations.push(CompositionOp::Filter(LowLevelFilterOp::Opacity(
-                            amount)));
+                        composition_operations.push(CompositionOp::Filter(
+                                LowLevelFilterOp::Opacity(Au::from_f32_px(amount))));
                     }
                     FilterOp::Saturate(amount) => {
-                        composition_operations.push(CompositionOp::Filter(LowLevelFilterOp::Saturate(
-                            amount)));
+                        composition_operations.push(CompositionOp::Filter(
+                                LowLevelFilterOp::Saturate(Au::from_f32_px(amount))));
                     }
                     FilterOp::Sepia(amount) => {
-                        composition_operations.push(CompositionOp::Filter(LowLevelFilterOp::Sepia(
-                            amount)));
+                        composition_operations.push(CompositionOp::Filter(
+                                LowLevelFilterOp::Sepia(Au::from_f32_px(amount))));
                     }
                 }
             }

--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -16,6 +16,7 @@ use util;
 
 const UV_FLOAT_TO_FIXED: f32 = 65535.0;
 const COLOR_FLOAT_TO_FIXED: f32 = 255.0;
+pub const ANGLE_FLOAT_TO_FIXED: f32 = 65535.0;
 
 pub const ORTHO_NEAR_PLANE: f32 = -1000000.0;
 pub const ORTHO_FAR_PLANE: f32 = 1000000.0;
@@ -864,14 +865,15 @@ impl<'a> CombinedClipRegion<'a> {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum LowLevelFilterOp {
     Blur(Au, BlurDirection),
-    Brightness(f32),
-    Contrast(f32),
-    Grayscale(f32),
-    HueRotate(f32),
-    Invert(f32),
-    Opacity(f32),
-    Saturate(f32),
-    Sepia(f32),
+    Brightness(Au),
+    Contrast(Au),
+    Grayscale(Au),
+    /// Fixed-point in `ANGLE_FLOAT_TO_FIXED` units.
+    HueRotate(i32),
+    Invert(Au),
+    Opacity(Au),
+    Saturate(Au),
+    Sepia(Au),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]


### PR DESCRIPTION
Alpha from a render target was not being correctly transferred to the
destination. To do this properly it seems that we need
`glBlendFuncSeparate`.

Additionally, this commit prepares for composite batching by eliminating
`f32` values from `LowLevelFilterOp` so as to ensure hashability.