### PR TITLE
Fix rotation of uv coordinates for box shadow pieces.

### DIFF
--- a/src/batch_builder.rs
+++ b/src/batch_builder.rs
@@ -948,7 +948,7 @@ impl<'a> BatchBuilder<'a> {
 
             // FIXME(pcwalton): Either use RGBA8 textures instead of alpha masks here, or implement
             // a mask combiner.
-            let mask_uv = RectUv::from_image_and_rotation_angle(mask_image, rotation_angle);
+            let mask_uv = RectUv::from_image_and_rotation_angle(mask_image, rotation_angle, true);
             let tessellated_rect = RectPosUv {
                 pos: tessellated_rect,
                 uv: mask_uv,
@@ -1069,7 +1069,7 @@ impl<'a> BatchBuilder<'a> {
         }
 
         let vertices_rect = Rect::new(*v0, Size2D::new(v1.x - v0.x, v1.y - v0.y));
-        let color_uv = RectUv::from_image_and_rotation_angle(color_image, rotation_angle);
+        let color_uv = RectUv::from_image_and_rotation_angle(color_image, rotation_angle, false);
 
         clipper::clip_rect_to_combined_region(RectPosUv {
                                                 pos: vertices_rect,

--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -568,10 +568,11 @@ pub struct RectUv {
 
 impl RectUv {
     pub fn from_image_and_rotation_angle(image: &TextureCacheItem,
-                                         rotation_angle: BasicRotationAngle)
+                                         rotation_angle: BasicRotationAngle,
+                                         flip_90_degree_rotations: bool)
                                          -> RectUv {
-        match rotation_angle {
-            BasicRotationAngle::Upright => {
+        match (rotation_angle, flip_90_degree_rotations) {
+            (BasicRotationAngle::Upright, _) => {
                 RectUv {
                     top_left: image.uv_rect.top_left,
                     top_right: image.uv_rect.top_right,
@@ -579,7 +580,7 @@ impl RectUv {
                     bottom_left: image.uv_rect.bottom_left,
                 }
             }
-            BasicRotationAngle::Clockwise90 => {
+            (BasicRotationAngle::Clockwise90, true) => {
                 RectUv {
                     top_right: image.uv_rect.top_left,
                     top_left: image.uv_rect.top_right,
@@ -587,7 +588,15 @@ impl RectUv {
                     bottom_right: image.uv_rect.bottom_left,
                 }
             }
-            BasicRotationAngle::Clockwise180 => {
+            (BasicRotationAngle::Clockwise90, false) => {
+                RectUv {
+                    top_right: image.uv_rect.top_left,
+                    bottom_right: image.uv_rect.top_right,
+                    bottom_left: image.uv_rect.bottom_right,
+                    top_left: image.uv_rect.bottom_left,
+                }
+            }
+            (BasicRotationAngle::Clockwise180, _) => {
                 RectUv {
                     bottom_right: image.uv_rect.top_left,
                     bottom_left: image.uv_rect.top_right,
@@ -595,12 +604,20 @@ impl RectUv {
                     top_right: image.uv_rect.bottom_left,
                 }
             }
-            BasicRotationAngle::Clockwise270 => {
+            (BasicRotationAngle::Clockwise270, true) => {
                 RectUv {
                     bottom_left: image.uv_rect.top_left,
                     bottom_right: image.uv_rect.top_right,
                     top_right: image.uv_rect.bottom_right,
                     top_left: image.uv_rect.bottom_left,
+                }
+            }
+            (BasicRotationAngle::Clockwise270, false) => {
+                RectUv {
+                    bottom_left: image.uv_rect.top_left,
+                    top_left: image.uv_rect.top_right,
+                    top_right: image.uv_rect.bottom_right,
+                    bottom_right: image.uv_rect.bottom_left,
                 }
             }
         }


### PR DESCRIPTION
Border corners actually have to flip when rotated, while box shadow
corners and sides don't.