### PR TITLE
Don't use a uniform to store the texture size in the filter shader.

### DIFF
--- a/res/es2_common.fs.glsl
+++ b/res/es2_common.fs.glsl
@@ -8,7 +8,6 @@ uniform vec4 uBlendParams;
 uniform vec4 uAtlasParams;
 uniform vec2 uDirection;
 uniform vec4 uFilterParams;
-uniform vec2 uTextureSize;
 
 varying vec2 vPosition;
 varying vec4 vColor;

--- a/res/es2_common.vs.glsl
+++ b/res/es2_common.vs.glsl
@@ -3,7 +3,6 @@
 uniform mat4 uTransform;
 uniform mat4 uMatrixPalette[32];
 uniform vec2 uDirection;
-uniform vec2 uTextureSize;
 uniform vec4 uBlendParams;
 uniform vec4 uFilterParams;
 uniform float uDevicePixelRatio;

--- a/res/filter.fs.glsl
+++ b/res/filter.fs.glsl
@@ -54,7 +54,9 @@ vec4 Blur(float radius, vec2 direction) {
     vec4 color = vec4(0.0);
     for (int offset = -range; offset <= range; offset++) {
         float offsetF = float(offset);
-        vec2 texCoord = vColorTexCoord.xy + vec2(offsetF) / uTextureSize * direction;
+
+        // Here, we use the vMaskTexCoord.xy (i.e. the muv) to store the texture size.
+        vec2 texCoord = vColorTexCoord.xy + vec2(offsetF) / vMaskTexCoord.xy * direction;
         vec4 x = texCoord.x >= 0.0 &&
             texCoord.x <= 1.0 &&
             texCoord.y >= 0.0 &&

--- a/res/filter.vs.glsl
+++ b/res/filter.vs.glsl
@@ -1,7 +1,7 @@
 void main(void)
 {
 	vColorTexCoord = vec3(aColorTexCoord, 0.0);
-	vMaskTexCoord = vec3(aMaskTexCoord / 65535.0, 0.0);
+	vMaskTexCoord = vec3(aMaskTexCoord, 0.0);
     gl_Position = uTransform * vec4(aPosition, 1.0);
 }
 

--- a/res/gl3_common.fs.glsl
+++ b/res/gl3_common.fs.glsl
@@ -8,7 +8,6 @@ uniform vec4 uBlendParams;
 uniform vec4 uAtlasParams;
 uniform vec2 uDirection;
 uniform vec4 uFilterParams;
-uniform vec2 uTextureSize;
 
 in vec2 vPosition;
 in vec4 vColor;

--- a/res/gl3_common.vs.glsl
+++ b/res/gl3_common.vs.glsl
@@ -3,7 +3,6 @@
 uniform mat4 uTransform;
 uniform mat4 uMatrixPalette[32];
 uniform vec2 uDirection;
-uniform vec2 uTextureSize;
 uniform vec4 uBlendParams;
 uniform vec4 uFilterParams;
 uniform float uDevicePixelRatio;

--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -168,6 +168,31 @@ impl PackedVertex {
         }
     }
 
+    /// Just like the above function, but doesn't scale the mask uv coordinates. This is useful
+    /// for the filter fragment shader, which uses the mask uv coordinates to store the texture
+    /// size.
+    pub fn from_components_unscaled_muv(x: f32, y: f32,
+                                        color: &ColorF,
+                                        u: f32, v: f32,
+                                        mu: u16, mv: u16,
+                                        uv_index: TextureIndex,
+                                        muv_index: TextureIndex)
+                                        -> PackedVertex {
+        PackedVertex {
+            x: x,
+            y: y,
+            color: PackedColor::from_color(color),
+            u: u,
+            v: v,
+            mu: mu,
+            mv: mv,
+            matrix_index: 0,
+            uv_index: uv_index.0,
+            muv_index: muv_index.0,
+            tile_params_index: 0,
+        }
+    }
+
     pub fn from_points(position: &Point2D<f32>,
                        color: &ColorF,
                        uv: &Point2D<f32>,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -63,7 +63,6 @@ pub struct Renderer {
 
     filter_program_id: ProgramId,
     u_filter_params: UniformLocation,
-    u_filter_texture_size: UniformLocation,
 
     box_shadow_program_id: ProgramId,
 
@@ -102,7 +101,6 @@ impl Renderer {
         let u_blend_params = device.get_uniform_location(blend_program_id, "uBlendParams");
 
         let u_filter_params = device.get_uniform_location(filter_program_id, "uFilterParams");
-        let u_filter_texture_size = device.get_uniform_location(filter_program_id, "uTextureSize");
 
         let u_direction = device.get_uniform_location(blur_program_id, "uDirection");
 
@@ -175,7 +173,6 @@ impl Renderer {
             blur_program_id: blur_program_id,
             u_blend_params: u_blend_params,
             u_filter_params: u_filter_params,
-            u_filter_texture_size: u_filter_texture_size,
             u_direction: u_direction,
             u_quad_transform_array: u_quad_transform_array,
             u_atlas_params: u_atlas_params,
@@ -1058,34 +1055,42 @@ impl Renderer {
                                 self.device.bind_program(self.blit_program_id, &render_context.projection);
                             }
 
-                            let color = ColorF::new(1.0, 1.0, 1.0, 1.0);
+                            let color = ColorF::new(1.0, 1.0, 1.0, alpha);
                             let indices: [u16; 6] = [ 0, 1, 2, 2, 3, 1 ];
                             let color_texture_index = TextureIndex(0);
                             let vertices: [PackedVertex; 4] = [
-                                PackedVertex::from_components(x0 as f32, y0 as f32,
-                                                              &color,
-                                                              0.0, 1.0,
-                                                              0.0, 1.0,
-                                                              color_texture_index,
-                                                              TextureIndex(0)),
-                                PackedVertex::from_components(x1 as f32, y0 as f32,
-                                                              &color,
-                                                              1.0, 1.0,
-                                                              1.0, 1.0,
-                                                              color_texture_index,
-                                                              TextureIndex(0)),
-                                PackedVertex::from_components(x0 as f32, y1 as f32,
-                                                              &color,
-                                                              0.0, 0.0,
-                                                              0.0, 0.0,
-                                                              color_texture_index,
-                                                              TextureIndex(0)),
-                                PackedVertex::from_components(x1 as f32, y1 as f32,
-                                                              &color,
-                                                              1.0, 0.0,
-                                                              1.0, 0.0,
-                                                              color_texture_index,
-                                                              TextureIndex(0)),
+                                PackedVertex::from_components_unscaled_muv(
+                                    x0 as f32, y0 as f32,
+                                    &color,
+                                    0.0, 1.0,
+                                    info.rect.size.width as u16,
+                                    info.rect.size.height as u16,
+                                    color_texture_index,
+                                    TextureIndex(0)),
+                                PackedVertex::from_components_unscaled_muv(
+                                    x1 as f32, y0 as f32,
+                                    &color,
+                                    1.0, 1.0,
+                                    info.rect.size.width as u16,
+                                    info.rect.size.height as u16,
+                                    color_texture_index,
+                                    TextureIndex(0)),
+                                PackedVertex::from_components_unscaled_muv(
+                                    x0 as f32, y1 as f32,
+                                    &color,
+                                    0.0, 0.0,
+                                    info.rect.size.width as u16,
+                                    info.rect.size.height as u16,
+                                    color_texture_index,
+                                    TextureIndex(0)),
+                                PackedVertex::from_components_unscaled_muv(
+                                    x1 as f32, y1 as f32,
+                                    &color,
+                                    1.0, 0.0,
+                                    info.rect.size.width as u16,
+                                    info.rect.size.height as u16,
+                                    color_texture_index,
+                                    TextureIndex(0)),
                             ];
                             // TODO: Don't re-create this VAO all the time.
                             // Create it once and set positions via uniforms.


### PR DESCRIPTION
It's incompatible with composite batching.