### PR TITLE
Remove use of texture arrays.

### DIFF
--- a/res/blend.fs.glsl
+++ b/res/blend.fs.glsl
@@ -141,8 +141,8 @@ vec3 Luminosity(vec3 Cb, vec3 Cs) {
 
 void main(void)
 {
-    vec3 Cs = Texture2D(sDiffuse2D, vColorTexCoord.xy).xyz;
-    vec3 Cb = Texture2D(sMask2D, vMaskTexCoord.xy).xyz;
+    vec3 Cs = Texture(sDiffuse, vColorTexCoord).xyz;
+    vec3 Cb = Texture(sMask, vMaskTexCoord).xyz;
 
     // TODO: Relies on the ordering of MixBlendMode enum!
     // TODO: May be best to have separate shaders (esp. on Tegra)

--- a/res/blend.vs.glsl
+++ b/res/blend.vs.glsl
@@ -1,6 +1,6 @@
 void main(void)
 {
-	vColorTexCoord = vec3(aColorTexCoord, 0.0);
-	vMaskTexCoord = vec3(aMaskTexCoord / 65535.0, 0.0);
+	vColorTexCoord = aColorTexCoord;
+	vMaskTexCoord = aMaskTexCoord / 65535.0;
     gl_Position = uTransform * vec4(aPosition, 1.0);
 }

--- a/res/blit.fs.glsl
+++ b/res/blit.fs.glsl
@@ -1,5 +1,5 @@
 void main(void)
 {
-    vec4 diffuse = Texture2D(sDiffuse2D, vColorTexCoord.xy);
+    vec4 diffuse = Texture(sDiffuse, vColorTexCoord.xy);
     SetFragColor(diffuse * vColor);
 }

--- a/res/blit.vs.glsl
+++ b/res/blit.vs.glsl
@@ -1,7 +1,7 @@
 void main(void)
 {
     vColor = aColor / 255.0;
-    vColorTexCoord = vec3(aColorTexCoord.xy, aMisc.y);
+    vColorTexCoord = aColorTexCoord;
     vec4 pos = vec4(aPosition, 1.0);
     pos.xy = floor(pos.xy * uDevicePixelRatio + 0.5) / uDevicePixelRatio;
     gl_Position = uTransform * pos;

--- a/res/blur.fs.glsl
+++ b/res/blur.fs.glsl
@@ -20,8 +20,7 @@ void main(void) {
             lColorTexCoord.x <= 1.0 &&
             lColorTexCoord.y >= 0.0 &&
             lColorTexCoord.y <= 1.0 ?
-            Texture(sDiffuse, vec3(lColorTexCoord * sourceTextureUvSize + sourceTextureUvOrigin,
-                                   vColorTexCoord.z)).r :
+            Texture(sDiffuse, lColorTexCoord * sourceTextureUvSize + sourceTextureUvOrigin).r :
             0.0;
         value += x * gauss(offsetF, sigma);
     }

--- a/res/blur.vs.glsl
+++ b/res/blur.vs.glsl
@@ -1,6 +1,6 @@
 void main(void)
 {
-	vColorTexCoord = vec3(aColorTexCoord, aMisc.y);
+	vColorTexCoord = aColorTexCoord;
     vBorderPosition = aBorderPosition;
     vBlurRadius = aBlurRadius;
     vDestTextureSize = aDestTextureSize;

--- a/res/es2_common.fs.glsl
+++ b/res/es2_common.fs.glsl
@@ -2,8 +2,6 @@
 
 uniform sampler2D sDiffuse;
 uniform sampler2D sMask;
-uniform sampler2D sDiffuse2D;
-uniform sampler2D sMask2D;
 uniform vec4 uBlendParams;
 uniform vec4 uAtlasParams;
 uniform vec2 uDirection;
@@ -11,8 +9,8 @@ uniform vec4 uFilterParams;
 
 varying vec2 vPosition;
 varying vec4 vColor;
-varying vec3 vColorTexCoord;
-varying vec3 vMaskTexCoord;
+varying vec2 vColorTexCoord;
+varying vec2 vMaskTexCoord;
 varying vec4 vBorderPosition;
 varying vec4 vBorderRadii;
 varying vec2 vDestTextureSize;
@@ -20,12 +18,8 @@ varying vec2 vSourceTextureSize;
 varying float vBlurRadius;
 varying vec4 vTileParams;
 
-vec4 Texture(sampler2D sampler, vec3 texCoord) {
-    return texture2D(sampler, texCoord.xy);
-}
-
-vec4 Texture2D(sampler2D sampler, vec2 texCoord) {
-    return texture(sampler, texCoord);
+vec4 Texture(sampler2D sampler, vec2 texCoord) {
+    return texture2D(sampler, texCoord);
 }
 
 float GetAlphaFromMask(vec4 mask) {

--- a/res/es2_common.vs.glsl
+++ b/res/es2_common.vs.glsl
@@ -17,12 +17,12 @@ attribute vec4 aBorderRadii;
 attribute vec2 aSourceTextureSize;
 attribute vec2 aDestTextureSize;
 attribute float aBlurRadius;
-attribute vec4 aMisc;   // x = matrix index; y = color tex index; z = mask tex index; w=tile params index
+attribute vec4 aMisc;   // x = matrix index; w = tile params index
 
 varying vec2 vPosition;
 varying vec4 vColor;
-varying vec3 vColorTexCoord;
-varying vec3 vMaskTexCoord;
+varying vec2 vColorTexCoord;
+varying vec2 vMaskTexCoord;
 varying vec4 vBorderPosition;
 varying vec4 vBorderRadii;
 varying vec2 vDestTextureSize;

--- a/res/filter.fs.glsl
+++ b/res/filter.fs.glsl
@@ -61,7 +61,7 @@ vec4 Blur(float radius, vec2 direction) {
             texCoord.x <= 1.0 &&
             texCoord.y >= 0.0 &&
             texCoord.y <= 1.0 ?
-            Texture2D(sDiffuse2D, texCoord) :
+            Texture(sDiffuse, texCoord) :
             vec4(0.0);
         color += x * gauss(offsetF, sigma);
     }
@@ -115,7 +115,7 @@ void main(void)
         // Gaussian blur is specially handled:
         result = Blur(amount, uFilterParams.zw);
     } else {
-        vec4 Cs = Texture2D(sDiffuse2D, vColorTexCoord.xy);
+        vec4 Cs = Texture(sDiffuse, vColorTexCoord);
 
         if (filterOp == 1) {
             result = Contrast(Cs, amount);

--- a/res/filter.vs.glsl
+++ b/res/filter.vs.glsl
@@ -1,7 +1,7 @@
 void main(void)
 {
-	vColorTexCoord = vec3(aColorTexCoord, 0.0);
-	vMaskTexCoord = vec3(aMaskTexCoord, 0.0);
+	vColorTexCoord = aColorTexCoord;
+	vMaskTexCoord = aMaskTexCoord;
     gl_Position = uTransform * vec4(aPosition, 1.0);
 }
 

--- a/res/gl3_common.fs.glsl
+++ b/res/gl3_common.fs.glsl
@@ -1,9 +1,7 @@
 #version 150
 
-uniform sampler2DArray sDiffuse;
-uniform sampler2DArray sMask;
-uniform sampler2D sDiffuse2D;
-uniform sampler2D sMask2D;
+uniform sampler2D sDiffuse;
+uniform sampler2D sMask;
 uniform vec4 uBlendParams;
 uniform vec4 uAtlasParams;
 uniform vec2 uDirection;
@@ -11,8 +9,8 @@ uniform vec4 uFilterParams;
 
 in vec2 vPosition;
 in vec4 vColor;
-in vec3 vColorTexCoord;
-in vec3 vMaskTexCoord;
+in vec2 vColorTexCoord;
+in vec2 vMaskTexCoord;
 in vec4 vBorderPosition;
 in vec4 vBorderRadii;
 in vec2 vDestTextureSize;
@@ -22,11 +20,7 @@ in vec4 vTileParams;
 
 out vec4 oFragColor;
 
-vec4 Texture(sampler2DArray sampler, vec3 texCoord) {
-    return texture(sampler, texCoord);
-}
-
-vec4 Texture2D(sampler2D sampler, vec2 texCoord) {
+vec4 Texture(sampler2D sampler, vec2 texCoord) {
     return texture(sampler, texCoord);
 }
 

--- a/res/gl3_common.vs.glsl
+++ b/res/gl3_common.vs.glsl
@@ -17,12 +17,12 @@ in vec4 aBorderRadii;
 in vec2 aSourceTextureSize;
 in vec2 aDestTextureSize;
 in float aBlurRadius;
-in vec4 aMisc;  // x = matrix index; y = color tex index; z = mask tex index; w=tile params index
+in vec4 aMisc;  // x = matrix index; w = tile params index
 
 out vec2 vPosition;
 out vec4 vColor;
-out vec3 vColorTexCoord;
-out vec3 vMaskTexCoord;
+out vec2 vColorTexCoord;
+out vec2 vMaskTexCoord;
 out vec4 vBorderPosition;
 out vec4 vBorderRadii;
 out vec2 vDestTextureSize;

--- a/res/quad.fs.glsl
+++ b/res/quad.fs.glsl
@@ -15,8 +15,8 @@ void main(void)
     vec2 snappedMaskTexCoord = dMask + floor(maskTexCoord * uAtlasParams.zw) / uAtlasParams.zw;
 
     // Fetch the diffuse and mask texels.
-    vec4 diffuse = Texture(sDiffuse, vec3(snappedColorTexCoord, vColorTexCoord.z));
-    vec4 mask = Texture(sMask, vec3(snappedMaskTexCoord, vMaskTexCoord.z));
+    vec4 diffuse = Texture(sDiffuse, snappedColorTexCoord);
+    vec4 mask = Texture(sMask, snappedMaskTexCoord);
 
     // Extract alpha from the mask (component depends on platform)
     float alpha = GetAlphaFromMask(mask);

--- a/res/quad.vs.glsl
+++ b/res/quad.vs.glsl
@@ -9,12 +9,12 @@ void main(void)
     vTileParams = uTileParams[int(aMisc.w)];
 
     // Normalize the mask texture coordinates.
-    vec2 maskTexCoord = aMaskTexCoord.xy / 65535.0;
-    vec2 colorTexCoord = aColorTexCoord.xy;
+    vec2 maskTexCoord = aMaskTexCoord / 65535.0;
+    vec2 colorTexCoord = aColorTexCoord;
 
     // Pass through the color and mask texture coordinates to fragment shader
-    vColorTexCoord = vec3(colorTexCoord, aMisc.y);
-    vMaskTexCoord = vec3(maskTexCoord, aMisc.z);
+    vColorTexCoord = colorTexCoord;
+    vMaskTexCoord = maskTexCoord;
 
     // Extract the complete (stacking context + css transform) transform
     // for this vertex. Transform the position by it.

--- a/res/tile.fs.glsl
+++ b/res/tile.fs.glsl
@@ -1,7 +1,6 @@
 void main(void) {
     vec2 textureSize = vBorderPosition.zw - vBorderPosition.xy;
-    vec3 colorTexCoord = vec3(vBorderPosition.xy + mod(vColorTexCoord.xy, 1.0) * textureSize,
-                              vColorTexCoord.z);
+    vec2 colorTexCoord = vBorderPosition.xy + mod(vColorTexCoord.xy, 1.0) * textureSize;
     vec4 diffuse = Texture(sDiffuse, colorTexCoord);
     SetFragColor(diffuse);
 }

--- a/res/tile.vs.glsl
+++ b/res/tile.vs.glsl
@@ -1,6 +1,6 @@
 void main(void)
 {
-	vColorTexCoord = vec3(aBorderRadii.xy, aMisc.y);
+	vColorTexCoord = aBorderRadii.xy;
     vBorderPosition = aBorderPosition;
     gl_Position = uTransform * vec4(aPosition, 1.0);
 }

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1,4 +1,4 @@
-use device::{ProgramId, TextureId, TextureIndex};
+use device::{ProgramId, TextureId};
 use internal_types::{BlurDirection, PackedVertex};
 use internal_types::{PackedVertexForTextureCacheUpdate, Primitive};
 use std::sync::atomic::Ordering::SeqCst;
@@ -209,7 +209,6 @@ pub struct RasterBatch {
     pub program_id: ProgramId,
     pub blur_direction: Option<BlurDirection>,
     pub dest_texture_id: TextureId,
-    pub dest_texture_index: TextureIndex,
     pub color_texture_id: TextureId,
     pub vertices: Vec<PackedVertexForTextureCacheUpdate>,
     pub indices: Vec<u16>,
@@ -219,7 +218,6 @@ impl RasterBatch {
     pub fn new(program_id: ProgramId,
                blur_direction: Option<BlurDirection>,
                dest_texture_id: TextureId,
-               dest_texture_index: TextureIndex,
                color_texture_id: TextureId)
                -> RasterBatch {
         debug_assert!(dest_texture_id != color_texture_id);
@@ -227,7 +225,6 @@ impl RasterBatch {
             program_id: program_id,
             blur_direction: blur_direction,
             dest_texture_id: dest_texture_id,
-            dest_texture_index: dest_texture_index,
             color_texture_id: color_texture_id,
             vertices: Vec::new(),
             indices: Vec::new(),
@@ -236,7 +233,6 @@ impl RasterBatch {
 
     pub fn can_add_to_batch(&self,
                             dest_texture_id: TextureId,
-                            dest_texture_index: TextureIndex,
                             color_texture_id: TextureId,
                             program_id: ProgramId,
                             blur_direction: Option<BlurDirection>)
@@ -244,16 +240,13 @@ impl RasterBatch {
         let batch_ok = program_id == self.program_id &&
             blur_direction == self.blur_direction &&
             dest_texture_id == self.dest_texture_id &&
-            dest_texture_index == self.dest_texture_index &&
             color_texture_id == self.color_texture_id;
         println!("batch ok? {:?} program_id={:?}/{:?} blur_direction={:?}/{:?} \
-                  dest_texture_id {:?}/{:?} dest_texture_index {:?}/{:?} \
-                  color_texture_id={:?}/{:?}",
+                  dest_texture_id {:?}/{:?} color_texture_id={:?}/{:?}",
                  batch_ok,
                  program_id, self.program_id,
                  blur_direction, self.blur_direction,
                  dest_texture_id, self.dest_texture_id,
-                 dest_texture_index, self.dest_texture_index,
                  color_texture_id, self.color_texture_id);
         batch_ok
     }

--- a/src/batch_builder.rs
+++ b/src/batch_builder.rs
@@ -1,7 +1,7 @@
 use app_units::Au;
 use batch::{BatchBuilder, MatrixIndex, TileParams};
 use clipper::{self, ClipBuffers, Polygon};
-use device::{TextureId, TextureIndex};
+use device::TextureId;
 use euclid::{Rect, Point2D, Size2D};
 use fnv::FnvHasher;
 use internal_types::{CombinedClipRegion, RectPosUv};
@@ -100,9 +100,7 @@ impl<'a> BatchBuilder<'a> {
         for clip_region in clip_buffers.rect_pos_uv.clip_rect_to_region_result_output.drain(..) {
             let mask = mask_for_clip_region(resource_cache, &clip_region, false);
             let colors = [*color, *color, *color, *color];
-            let mut vertices = clip_region.make_packed_vertices_for_rect(&colors,
-                                                                         mask,
-                                                                         image_info.texture_index);
+            let mut vertices = clip_region.make_packed_vertices_for_rect(&colors, mask);
 
             self.add_draw_item(matrix_index,
                                image_info.texture_id,
@@ -136,7 +134,7 @@ impl<'a> BatchBuilder<'a> {
         let mut glyph_key = GlyphKey::new(font_key, size, blur_radius, glyphs[0].index);
         let blur_offset = blur_radius.to_f32_px() * (BLUR_INFLATION_FACTOR as f32) / 2.0;
 
-        let mut text_batches: HashMap<(TextureId, TextureIndex), Vec<RectPosUv>, DefaultState<FnvHasher>> =
+        let mut text_batches: HashMap<TextureId, Vec<RectPosUv>, DefaultState<FnvHasher>> =
             HashMap::with_hash_state(Default::default());
 
         for glyph in glyphs {
@@ -154,14 +152,9 @@ impl<'a> BatchBuilder<'a> {
                     uv: image_info.uv_rect,
                 };
 
-                let rect_buffer = match text_batches.entry((image_info.texture_id,
-                                                            image_info.texture_index)) {
-                    Occupied(entry) => {
-                        entry.into_mut()
-                    }
-                    Vacant(entry) => {
-                        entry.insert(Vec::new())
-                    }
+                let rect_buffer = match text_batches.entry(image_info.texture_id) {
+                    Occupied(entry) => entry.into_mut(),
+                    Vacant(entry) => entry.insert(Vec::new()),
                 };
 
                 rect_buffer.push(rect);
@@ -169,7 +162,7 @@ impl<'a> BatchBuilder<'a> {
         }
 
         let mut vertex_buffer = Vec::new();
-        for ((texture_id, texture_index), mut rect_buffer) in text_batches {
+        for (texture_id, mut rect_buffer) in text_batches {
             let rect_buffer = if need_text_clip {
                 let mut clipped_rects = Vec::new();
                 for rect in rect_buffer.drain(..) {
@@ -194,30 +187,26 @@ impl<'a> BatchBuilder<'a> {
                         x0, y0,
                         color,
                         rect.uv.top_left.x, rect.uv.top_left.y,
-                        dummy_mask_image.uv_rect.top_left.x, dummy_mask_image.uv_rect.top_left.y,
-                        texture_index,
-                        dummy_mask_image.texture_index));
+                        dummy_mask_image.uv_rect.top_left.x,
+                        dummy_mask_image.uv_rect.top_left.y));
                 vertex_buffer.push(PackedVertex::from_components(
                         x1, y0,
                         color,
                         rect.uv.top_right.x, rect.uv.top_right.y,
-                        dummy_mask_image.uv_rect.top_right.x, dummy_mask_image.uv_rect.top_right.y,
-                        texture_index,
-                        dummy_mask_image.texture_index));
+                        dummy_mask_image.uv_rect.top_right.x,
+                        dummy_mask_image.uv_rect.top_right.y));
                 vertex_buffer.push(PackedVertex::from_components(
                         x0, y1,
                         color,
                         rect.uv.bottom_left.x, rect.uv.bottom_left.y,
-                        dummy_mask_image.uv_rect.bottom_left.x, dummy_mask_image.uv_rect.bottom_left.y,
-                        texture_index,
-                        dummy_mask_image.texture_index));
+                        dummy_mask_image.uv_rect.bottom_left.x,
+                        dummy_mask_image.uv_rect.bottom_left.y));
                 vertex_buffer.push(PackedVertex::from_components(
                         x1, y1,
                         color,
                         rect.uv.bottom_right.x, rect.uv.bottom_right.y,
-                        dummy_mask_image.uv_rect.bottom_right.x, dummy_mask_image.uv_rect.bottom_right.y,
-                        texture_index,
-                        dummy_mask_image.texture_index));
+                        dummy_mask_image.uv_rect.bottom_right.x,
+                        dummy_mask_image.uv_rect.bottom_right.y));
             }
 
             self.add_draw_item(matrix_index,
@@ -272,9 +261,7 @@ impl<'a> BatchBuilder<'a> {
         for clip_region in clip_buffers.rect_pos_uv.clip_rect_to_region_result_output.drain(..) {
             let mask = mask_for_clip_region(resource_cache, &clip_region, false);
 
-            let mut vertices = clip_region.make_packed_vertices_for_rect(colors,
-                                                                         mask,
-                                                                         image_info.texture_index);
+            let mut vertices = clip_region.make_packed_vertices_for_rect(colors, mask);
 
             self.add_draw_item(matrix_index,
                                image_info.texture_id,
@@ -358,12 +345,10 @@ impl<'a> BatchBuilder<'a> {
                     let mut packed_vertices = Vec::new();
                     if clip_result.rect_result.vertices.len() >= 3 {
                         for vert in clip_result.rect_result.vertices.iter() {
-                            packed_vertices.push(clip_result.make_packed_vertex(
-                                    &vert.position(),
-                                    &vert.uv(),
-                                    &vert.color(),
-                                    &mask,
-                                    white_image.texture_index));
+                            packed_vertices.push(clip_result.make_packed_vertex(&vert.position(),
+                                                                                &vert.uv(),
+                                                                                &vert.color(),
+                                                                                &mask));
                         }
                     }
 
@@ -1007,42 +992,12 @@ impl<'a> BatchBuilder<'a> {
                 }
 
                 let mut vertices = [
-                    PackedVertex::from_components(v0.x, v0.y,
-                                                  color0,
-                                                  0.0, 0.0,
-                                                  muv0.x, muv0.y,
-                                                  white_image.texture_index,
-                                                  mask_image.texture_index),
-                    PackedVertex::from_components(v1.x, v1.y,
-                                                  color0,
-                                                  0.0, 0.0,
-                                                  muv2.x, muv2.y,
-                                                  white_image.texture_index,
-                                                  mask_image.texture_index),
-                    PackedVertex::from_components(v0.x, v1.y,
-                                                  color0,
-                                                  0.0, 0.0,
-                                                  muv3.x, muv3.y,
-                                                  white_image.texture_index,
-                                                  mask_image.texture_index),
-                    PackedVertex::from_components(v0.x, v0.y,
-                                                  color1,
-                                                  0.0, 0.0,
-                                                  muv0.x, muv0.y,
-                                                  white_image.texture_index,
-                                                  mask_image.texture_index),
-                    PackedVertex::from_components(v1.x, v0.y,
-                                                  color1,
-                                                  0.0, 0.0,
-                                                  muv1.x, muv1.y,
-                                                  white_image.texture_index,
-                                                  mask_image.texture_index),
-                    PackedVertex::from_components(v1.x, v1.y,
-                                                  color1,
-                                                  0.0, 0.0,
-                                                  muv2.x, muv2.y,
-                                                  white_image.texture_index,
-                                                  mask_image.texture_index),
+                    PackedVertex::from_components(v0.x, v0.y, color0, 0.0, 0.0, muv0.x, muv0.y),
+                    PackedVertex::from_components(v1.x, v1.y, color0, 0.0, 0.0, muv2.x, muv2.y),
+                    PackedVertex::from_components(v0.x, v1.y, color0, 0.0, 0.0, muv3.x, muv3.y),
+                    PackedVertex::from_components(v0.x, v0.y, color1, 0.0, 0.0, muv0.x, muv0.y),
+                    PackedVertex::from_components(v1.x, v0.y, color1, 0.0, 0.0, muv1.x, muv1.y),
+                    PackedVertex::from_components(v1.x, v1.y, color1, 0.0, 0.0, muv2.x, muv2.y),
                 ];
 
                 self.add_draw_item(matrix_index,
@@ -1085,9 +1040,7 @@ impl<'a> BatchBuilder<'a> {
                                             &clip_region,
                                             false);
             let colors = [*color0, *color0, *color1, *color1];
-            let mut vertices = clip_region.make_packed_vertices_for_rect(&colors,
-                                                                         mask,
-                                                                         color_image.texture_index);
+            let mut vertices = clip_region.make_packed_vertices_for_rect(&colors, mask);
 
             self.add_draw_item(matrix_index,
                                color_image.texture_id,

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -4,7 +4,7 @@ use device::{TextureId};
 use euclid::{Rect, Point2D, Size2D, Matrix4};
 use fnv::FnvHasher;
 use internal_types::{BlurDirection, LowLevelFilterOp, CompositionOp, DrawListItemIndex};
-use internal_types::{BatchUpdateList, DrawListId, TextureTarget};
+use internal_types::{BatchUpdateList, DrawListId};
 use internal_types::{RendererFrame, DrawListContext, BatchInfo, DrawCall};
 use internal_types::{BatchUpdate, BatchUpdateOp, DrawLayer};
 use internal_types::{DrawCommand, ClearInfo, CompositeInfo, ANGLE_FLOAT_TO_FIXED};
@@ -467,10 +467,8 @@ impl Frame {
                 // TODO(gw): Get composition ops working with transforms
                 let origin = Point2D::new(child_offset.x as u32, child_offset.y as u32);
 
-                let texture_id = resource_cache.allocate_render_target(TextureTarget::Texture2D,
-                                                                       size.width,
+                let texture_id = resource_cache.allocate_render_target(size.width,
                                                                        size.height,
-                                                                       1,
                                                                        ImageFormat::RGBA8);
 
                 self.push_composite(CompositeInfo {

--- a/src/resource_cache.rs
+++ b/src/resource_cache.rs
@@ -4,7 +4,7 @@ use euclid::Size2D;
 use fnv::FnvHasher;
 use freelist::FreeList;
 use internal_types::{FontTemplate, GlyphKey, RasterItem};
-use internal_types::{TextureTarget, TextureUpdateList, DrawListId, DrawList};
+use internal_types::{TextureUpdateList, DrawListId, DrawList};
 use platform::font::{FontContext, RasterizedGlyph};
 use renderer::BLUR_INFLATION_FACTOR;
 use resource_list::ResourceList;
@@ -285,18 +285,9 @@ impl ResourceCache {
         self.draw_lists.free(draw_list_id);
     }
 
-    pub fn allocate_render_target(&mut self,
-                                  target: TextureTarget,
-                                  width: u32,
-                                  height: u32,
-                                  levels: u32,
-                                  format: ImageFormat)
+    pub fn allocate_render_target(&mut self, width: u32, height: u32, format: ImageFormat)
                                   -> TextureId {
-        self.texture_cache.allocate_render_target(target,
-                                                  width,
-                                                  height,
-                                                  levels,
-                                                  format)
+        self.texture_cache.allocate_render_target(width, height, format)
     }
 
     pub fn free_render_target(&mut self, texture_id: TextureId) {


### PR DESCRIPTION
The only real thing we need texture arrays for is to get around texture
size limitations, but we believe these are generally so high nowadays as
to not matter--at least on OpenGL 3.0+ hardware, which is the minimum
version required for texture arrays to begin with.