### PR TITLE
Batch similar composite operations together.

### DIFF
--- a/res/blit.fs.glsl
+++ b/res/blit.fs.glsl
@@ -1,5 +1,5 @@
 void main(void)
 {
-    vec4 diffuse = Texture(sDiffuse, vColorTexCoord.xy);
+    vec4 diffuse = Texture(sDiffuse, vColorTexCoord);
     SetFragColor(diffuse * vColor);
 }

--- a/res/box_shadow.fs.glsl
+++ b/res/box_shadow.fs.glsl
@@ -19,7 +19,7 @@ void main(void)
     float length;
     float value;
     vec2 position = vPosition - vBorderPosition.zw;
-    if (vBorderRadii.y == 0.0) {
+    if (vBorderRadii.z == 0.0) {
         length = range;
         value = position.x;
     } else {

--- a/res/clear.fs.glsl
+++ b/res/clear.fs.glsl
@@ -1,0 +1,4 @@
+void main(void)
+{
+    SetFragColor(vColor);
+}

--- a/res/clear.vs.glsl
+++ b/res/clear.vs.glsl
@@ -1,0 +1,5 @@
+void main(void)
+{
+    vColor = aColor / 255.0;
+    gl_Position = uTransform * vec4(aPosition, 1.0);
+}

--- a/src/device.rs
+++ b/src/device.rs
@@ -723,6 +723,7 @@ impl Device {
         }
     }
 
+    #[allow(dead_code)]
     pub fn deinit_texture(&mut self, texture_id: TextureId) {
         debug_assert!(self.inside_frame);
 
@@ -906,13 +907,13 @@ impl Device {
                              data);
     }
 
-    pub fn update_texture(&mut self,
-                          texture_id: TextureId,
-                          x0: u32,
-                          y0: u32,
-                          width: u32,
-                          height: u32,
-                          data: &[u8]) {
+    fn update_texture(&mut self,
+                      texture_id: TextureId,
+                      x0: u32,
+                      y0: u32,
+                      width: u32,
+                      height: u32,
+                      data: &[u8]) {
         debug_assert!(self.inside_frame);
 
         let (gl_format, bpp) = match self.textures.get(&texture_id).unwrap().format {
@@ -945,8 +946,8 @@ impl Device {
 
     fn read_framebuffer_rect_for_2d_texture(&mut self,
                                             texture_id: TextureId,
-                                            x: u32, y: u32,
-                                            width: u32, height: u32) {
+                                            x: i32, y: i32,
+                                            width: i32, height: i32) {
         self.bind_color_texture(texture_id);
         gl::copy_tex_sub_image_2d(gl::TEXTURE_2D,
                                   0,
@@ -958,10 +959,10 @@ impl Device {
 
     pub fn read_framebuffer_rect(&mut self,
                                  texture_id: TextureId,
-                                 x: u32,
-                                 y: u32,
-                                 width: u32,
-                                 height: u32) {
+                                 x: i32,
+                                 y: i32,
+                                 width: i32,
+                                 height: i32) {
         self.read_framebuffer_rect_for_2d_texture(texture_id, x, y, width, height)
     }
 

--- a/src/node_compiler.rs
+++ b/src/node_compiler.rs
@@ -1,7 +1,7 @@
 use aabbtree::AABBTreeNode;
 use batch::{BatchBuilder, MatrixIndex, VertexBuffer};
 use clipper::{ClipBuffers};
-use frame::{FrameRenderItem, FrameRenderTarget};
+use frame::{FrameRenderItem, FrameRenderTargetGroup};
 use internal_types::{DrawListItemIndex, CompiledNode, CombinedClipRegion, BatchList};
 use resource_cache::ResourceCache;
 use webrender_traits::SpecificDisplayItem;
@@ -9,25 +9,25 @@ use webrender_traits::SpecificDisplayItem;
 pub trait NodeCompiler {
     fn compile(&mut self,
                resource_cache: &ResourceCache,
-               render_targets: &Vec<FrameRenderTarget>,
+               render_target_groups: &Vec<FrameRenderTargetGroup>,
                device_pixel_ratio: f32);
 }
 
 impl NodeCompiler for AABBTreeNode {
     fn compile(&mut self,
                resource_cache: &ResourceCache,
-               render_targets: &Vec<FrameRenderTarget>,
+               render_target_groups: &Vec<FrameRenderTargetGroup>,
                device_pixel_ratio: f32) {
         let mut compiled_node = CompiledNode::new();
         let mut vertex_buffer = VertexBuffer::new();
 
         let mut clip_buffers = ClipBuffers::new();
 
-        for render_target in render_targets {
-            for item in &render_target.items {
+        for render_target_group in render_target_groups {
+            for item in &render_target_group.items {
                 match item {
                     &FrameRenderItem::Clear(..) |
-                    &FrameRenderItem::Composite(..) => {}
+                    &FrameRenderItem::CompositeBatch(..) => {}
                     &FrameRenderItem::DrawListBatch(ref batch_info) => {
                         // TODO: Move this to outer loop when combining with >1 draw list!
                         let mut builder = BatchBuilder::new(&mut vertex_buffer);

--- a/src/render_backend.rs
+++ b/src/render_backend.rs
@@ -1,6 +1,6 @@
 use euclid::{Rect, Size2D};
 use frame::Frame;
-use internal_types::{FontTemplate, ResultMsg, DrawLayer, RendererFrame};
+use internal_types::{FontTemplate, FrameRenderTarget, ResultMsg, DrawLayer, RendererFrame};
 use ipc_channel::ipc::IpcReceiver;
 use profiler::BackendProfileCounters;
 use resource_cache::ResourceCache;
@@ -266,6 +266,7 @@ impl RenderBackend {
         self.frame.create(&self.scene,
                           Size2D::new(self.viewport.size.width as u32,
                                       self.viewport.size.height as u32),
+                          self.device_pixel_ratio,
                           &mut self.resource_cache,
                           &mut new_pipeline_sizes);
 
@@ -328,10 +329,12 @@ impl RenderBackend {
         // cleared to the default UA background color. Perhaps
         // there is a better way to handle this...
         if frame.layers.len() == 0 {
+            let size = Size2D::new(self.viewport.size.width as u32,
+                                   self.viewport.size.height as u32);
             frame.layers.push(DrawLayer {
+                render_targets: vec![FrameRenderTarget::new(size, None)],
                 texture_id: None,
-                size: Size2D::new(self.viewport.size.width as u32,
-                                   self.viewport.size.height as u32),
+                size: size,
                 commands: Vec::new(),
             });
         }


### PR DESCRIPTION
Known bugs and limitations:

* Only 32 composite operations can be batched, because that is the
  maximum size of the matrix palette.

* Nested composite operations aren't correctly handled at the moment.
  They use the wrong device pixel ratio and read from and write to the
  same texture, which is undefined behavior (although usually works).

* When a large number (>700 in my tests) of composite operations occur,
  there can be stray triangles drawn. I haven't been able to pin down
  why that occurs yet.

Please review this carefully if you get time; this is tricky stuff and I'm sure I've messed up :)