### PR TITLE
Add WebGL support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ git = "https://github.com/servo/ipc-channel"
 [dependencies.webrender_traits]
 git = "https://github.com/glennw/webrender_traits"
 
+[dependencies.offscreen_gl_context]
+git = "https://github.com/ecoal95/rust-offscreen-rendering-context"
+branch = "webrender"
+
 [dependencies]
 gleam = "*"
 euclid = "0.3"

--- a/res/gl3_common.fs.glsl
+++ b/res/gl3_common.fs.glsl
@@ -1,4 +1,4 @@
-#version 150
+#version 130
 
 #define SERVO_GL3
 

--- a/res/gl3_common.vs.glsl
+++ b/res/gl3_common.vs.glsl
@@ -1,4 +1,4 @@
-#version 150
+#version 130
 
 #define SERVO_GL3
 

--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -243,6 +243,7 @@ pub enum RenderTargetMode {
 
 #[derive(Debug)]
 pub enum TextureUpdateDetails {
+    Raw,
     Blit(Vec<u8>),
     Blur(Vec<u8>, Size2D<u32>, Au, TextureImage, TextureImage),
     /// All four corners, the tessellation index, and whether inverted, respectively.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ extern crate ipc_channel;
 extern crate scoped_threadpool;
 extern crate time;
 extern crate webrender_traits;
+extern crate offscreen_gl_context;
 
 pub use renderer::Renderer;
 

--- a/src/node_compiler.rs
+++ b/src/node_compiler.rs
@@ -60,6 +60,14 @@ impl NodeCompiler for AABBTreeNode {
                                             &display_item.clip.complex[..]);
 
                                         match display_item.item {
+                                            SpecificDisplayItem::WebGL(ref info) => {
+                                                builder.add_webgl_rectangle(matrix_index,
+                                                                            &display_item.rect,
+                                                                            &clip,
+                                                                            resource_cache,
+                                                                            &mut clip_buffers,
+                                                                            &info.context_id);
+                                            }
                                             SpecificDisplayItem::Image(ref info) => {
                                                 builder.add_image(matrix_index,
                                                                   &display_item.rect,

--- a/src/resource_list.rs
+++ b/src/resource_list.rs
@@ -147,6 +147,7 @@ impl BuildRequiredResources for AABBTreeNode {
                             resource_list.add_glyph(info.font_key, glyph);
                         }
                     }
+                    SpecificDisplayItem::WebGL(..) => {}
                     SpecificDisplayItem::Rectangle(..) => {}
                     SpecificDisplayItem::Gradient(..) => {}
                     SpecificDisplayItem::BoxShadow(ref info) => {

--- a/src/texture_cache.rs
+++ b/src/texture_cache.rs
@@ -43,7 +43,7 @@ pub enum BorderType {
 }
 
 #[inline]
-fn copy_pixels(src: &Vec<u8>,
+fn copy_pixels(src: &[u8],
                target: &mut Vec<u8>,
                x: u32,
                y: u32,
@@ -793,6 +793,16 @@ impl TextureCache {
         };
 
         self.pending_updates.push(update_op);
+    }
+
+    pub fn add_raw_update(&mut self, id: TextureId, size: Size2D<i32>) {
+        self.pending_updates.push(TextureUpdate {
+            id: id,
+            op: TextureUpdateOp::Update(
+                0, 0,
+                size.width as u32, size.height as u32,
+                TextureUpdateDetails::Raw),
+        })
     }
 
     pub fn update(&mut self,


### PR DESCRIPTION
For now it only has support for `clear`/`clearColor`, but adding support for more is easy (see `apply_webgl_command`).

It depends on a few more PRs (to servo and webrender_traits) and on the `webrender` branch of `offscreen_gl_context`, that currently lacks support for OS X since I don't own a Mac, but it should fail gracefully (just returning `null` on context creation).

It uses the last approach discussed in #73 

cc: @pcwalton @mrobinson