### PR TITLE
webgl: Flip WebGL items vertically

### DIFF
--- a/src/batch_builder.rs
+++ b/src/batch_builder.rs
@@ -69,10 +69,10 @@ impl<'a> BatchBuilder<'a> {
         let texture_id = resource_cache.get_webgl_texture(webgl_context_id);
 
         let uv = RectUv {
-            top_left: Point2D::zero(),
-            top_right: Point2D::new(1.0, 0.0),
-            bottom_left: Point2D::new(0.0, 1.0),
-            bottom_right: Point2D::new(1.0, 1.0),
+            top_left: Point2D::new(0.0, 1.0),
+            top_right: Point2D::new(1.0, 1.0),
+            bottom_left: Point2D::zero(),
+            bottom_right: Point2D::new(1.0, 0.0),
         };
 
         clipper::clip_rect_to_combined_region(


### PR DESCRIPTION
We do it [on the CPU](https://github.com/servo/servo/blob/master/components/canvas/webgl_paint_task.rs#L358) on servo, this way we correctly render the remaining
tests, including the WebGL triangle and the texture test.

Performance is pretty awesome compared with current servo (as expected though).

![servo-webrender-webgl-triangle](https://cloud.githubusercontent.com/assets/1323194/11574135/1b2f1fec-9a0a-11e5-9905-2986ad4f529a.png)
![webrender-webgl-texture](https://cloud.githubusercontent.com/assets/1323194/11574141/2116137a-9a0a-11e5-8568-f7b5cec15240.png)
