### PR TITLE
Avoid overflowing indices in batches.

### DIFF
--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -353,7 +353,7 @@ pub struct DrawCall {
     pub vertex_buffer_id: VertexBufferId,
     pub color_texture_id: TextureId,
     pub mask_texture_id: TextureId,
-    pub first_vertex: u16,
+    pub first_vertex: u32,
     pub index_count: u16,
 }
 


### PR DESCRIPTION
This switches WebRender to use a u32 index internally for batches and to
generate new batches when a u16 overflow would occur. Indices are still
truncated to u16 before sending the batches to OpenGL.