### PR TITLE
Partially fix blur filters.

### DIFF
--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -1030,3 +1030,18 @@ pub enum CompositionOp {
     MixBlend(MixBlendMode),
     Filter(LowLevelFilterOp),
 }
+
+impl CompositionOp {
+    pub fn target_rect(&self, unfiltered_target_rect: &Rect<i32>) -> Rect<i32> {
+        match *self {
+            CompositionOp::Filter(LowLevelFilterOp::Blur(amount, AxisDirection::Horizontal)) => {
+                unfiltered_target_rect.inflate(amount.to_f32_px() as i32, 0)
+            }
+            CompositionOp::Filter(LowLevelFilterOp::Blur(amount, AxisDirection::Vertical)) => {
+                unfiltered_target_rect.inflate(0, amount.to_f32_px() as i32)
+            }
+            _ => *unfiltered_target_rect,
+        }
+    }
+}
+


### PR DESCRIPTION
* The temporary framebuffer texture is now unused, since we use separate
  render targets instead of readback. This patch removes it.

* We now write the texture sizes into the mask UV coordinates properly.

* We allow composite filters to inflate the dimensions of their render
  targets. This means that blurs can draw outside their rects.

Remaining issues:

* Blur filters need to not read outside of the render target in the
  atlas.

* The vertical blur needs to blur the render target that the horizontal
  blur wrote to rather than the original render target.