### PR TITLE
Fix a couple of correctness issues around border-radius.

### DIFF
--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -247,7 +247,7 @@ pub enum TextureUpdateDetails {
     Blit(Vec<u8>),
     Blur(Vec<u8>, Size2D<u32>, Au, TextureImage, TextureImage),
     /// All four corners, the tessellation index, and whether inverted, respectively.
-    BorderRadius(Au, Au, Au, Au, u32, bool),
+    BorderRadius(Au, Au, Au, Au, Option<u32>, bool),
     /// Blur radius, border radius, box rect, raster origin, and whether inverted, respectively.
     BoxShadow(Au, Au, Rect<f32>, Point2D<f32>, bool),
 }
@@ -614,6 +614,12 @@ pub struct RectPolygon<Varyings> {
     pub varyings: Varyings,
 }
 
+impl<Varyings> RectPolygon<Varyings> {
+    pub fn is_well_formed_and_nonempty(&self) -> bool {
+        util::rect_is_well_formed_and_nonempty(&self.pos)
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct RectColorsUv {
     pub colors: RectColors,
@@ -648,6 +654,15 @@ pub struct RectUv {
 }
 
 impl RectUv {
+    pub fn zero() -> RectUv {
+        RectUv {
+            top_left: Point2D::new(0.0, 0.0),
+            top_right: Point2D::new(0.0, 0.0),
+            bottom_left: Point2D::new(0.0, 0.0),
+            bottom_right: Point2D::new(0.0, 0.0),
+        }
+    }
+
     pub fn from_image_and_rotation_angle(image: &TextureCacheItem,
                                          rotation_angle: BasicRotationAngle,
                                          flip_90_degree_rotations: bool)
@@ -820,7 +835,7 @@ pub struct BorderRadiusRasterOp {
     pub outer_radius_y: Au,
     pub inner_radius_x: Au,
     pub inner_radius_y: Au,
-    pub index: u32,
+    pub index: Option<u32>,
     pub image_format: ImageFormat,
     pub inverted: bool,
 }
@@ -829,7 +844,7 @@ impl BorderRadiusRasterOp {
     pub fn create(outer_radius: &Size2D<f32>,
                   inner_radius: &Size2D<f32>,
                   inverted: bool,
-                  index: u32,
+                  index: Option<u32>,
                   image_format: ImageFormat)
                   -> Option<BorderRadiusRasterOp> {
         if outer_radius.width > 0.0 || outer_radius.height > 0.0 {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -565,12 +565,16 @@ impl Renderer {
                                 let tessellated_rect =
                                     Rect::new(Point2D::new(0.0, 0.0),
                                               Size2D::new(outer_rx, outer_ry));
-                                let tessellated_rect =
-                                    tessellated_rect.tessellate_border_corner(
-                                        &Size2D::new(outer_rx, outer_ry),
-                                        &Size2D::new(inner_rx, inner_ry),
-                                        BasicRotationAngle::Upright,
-                                        index);
+                                let tessellated_rect = match index {
+                                    None => tessellated_rect,
+                                    Some(index) => {
+                                        tessellated_rect.tessellate_border_corner(
+                                            &Size2D::new(outer_rx, outer_ry),
+                                            &Size2D::new(inner_rx, inner_ry),
+                                            BasicRotationAngle::Upright,
+                                            index)
+                                    }
+                                };
                                 let border_position =
                                     Point2D::new(x - tessellated_rect.origin.x + outer_rx,
                                                  y - tessellated_rect.origin.y + outer_ry);

--- a/src/resource_list.rs
+++ b/src/resource_list.rs
@@ -55,7 +55,7 @@ impl ResourceList {
                              outer_radius: &Size2D<f32>,
                              inner_radius: &Size2D<f32>,
                              inverted: bool,
-                             index: u32,
+                             index: Option<u32>,
                              image_format: ImageFormat) {
         if let Some(raster_item) = BorderRadiusRasterOp::create(outer_radius,
                                                                 inner_radius,
@@ -66,12 +66,13 @@ impl ResourceList {
         }
     }
 
+    /// NB: Only adds non-tessellated border radii.
     pub fn add_radius_raster_for_border_radii(&mut self, radii: &BorderRadius) {
         let zero_size = Size2D::new(0.0, 0.0);
-        self.add_radius_raster(&radii.top_left, &zero_size, false, 0, ImageFormat::A8);
-        self.add_radius_raster(&radii.top_right, &zero_size, false, 0, ImageFormat::A8);
-        self.add_radius_raster(&radii.bottom_left, &zero_size, false, 0, ImageFormat::A8);
-        self.add_radius_raster(&radii.bottom_right, &zero_size, false, 0, ImageFormat::A8);
+        self.add_radius_raster(&radii.top_left, &zero_size, false, None, ImageFormat::A8);
+        self.add_radius_raster(&radii.top_right, &zero_size, false, None, ImageFormat::A8);
+        self.add_radius_raster(&radii.bottom_left, &zero_size, false, None, ImageFormat::A8);
+        self.add_radius_raster(&radii.bottom_right, &zero_size, false, None, ImageFormat::A8);
     }
 
     pub fn add_box_shadow_corner(&mut self,
@@ -194,7 +195,7 @@ impl BuildRequiredResources for AABBTreeNode {
                                 resource_list.add_radius_raster(&info.radius.top_left,
                                                                 &info.top_left_inner_radius(),
                                                                 false,
-                                                                rect_index,
+                                                                Some(rect_index),
                                                                 ImageFormat::A8);
                             }
                             for rect_index in 0..tessellator::quad_count_for_border_corner(
@@ -202,7 +203,7 @@ impl BuildRequiredResources for AABBTreeNode {
                                 resource_list.add_radius_raster(&info.radius.top_right,
                                                                 &info.top_right_inner_radius(),
                                                                 false,
-                                                                rect_index,
+                                                                Some(rect_index),
                                                                 ImageFormat::A8);
                             }
                             for rect_index in 0..tessellator::quad_count_for_border_corner(
@@ -210,7 +211,7 @@ impl BuildRequiredResources for AABBTreeNode {
                                 resource_list.add_radius_raster(&info.radius.bottom_left,
                                                                 &info.bottom_left_inner_radius(),
                                                                 false,
-                                                                rect_index,
+                                                                Some(rect_index),
                                                                 ImageFormat::A8);
                             }
                             for rect_index in 0..tessellator::quad_count_for_border_corner(
@@ -218,7 +219,7 @@ impl BuildRequiredResources for AABBTreeNode {
                                 resource_list.add_radius_raster(&info.radius.bottom_right,
                                                                 &info.bottom_right_inner_radius(),
                                                                 false,
-                                                                rect_index,
+                                                                Some(rect_index),
                                                                 ImageFormat::A8);
                             }
 
@@ -227,7 +228,7 @@ impl BuildRequiredResources for AABBTreeNode {
                                                                              info.top.width / 2.0),
                                                                 &Size2D::new(0.0, 0.0),
                                                                 false,
-                                                                0,
+                                                                None,
                                                                 ImageFormat::RGBA8);
                             }
                             if info.right.style == BorderStyle::Dotted {
@@ -235,7 +236,7 @@ impl BuildRequiredResources for AABBTreeNode {
                                                                              info.right.width / 2.0),
                                                                 &Size2D::new(0.0, 0.0),
                                                                 false,
-                                                                0,
+                                                                None,
                                                                 ImageFormat::RGBA8);
                             }
                             if info.bottom.style == BorderStyle::Dotted {
@@ -243,7 +244,7 @@ impl BuildRequiredResources for AABBTreeNode {
                                                                              info.bottom.width / 2.0),
                                                                 &Size2D::new(0.0, 0.0),
                                                                 false,
-                                                                0,
+                                                                None,
                                                                 ImageFormat::RGBA8);
                             }
                             if info.left.style == BorderStyle::Dotted {
@@ -251,7 +252,7 @@ impl BuildRequiredResources for AABBTreeNode {
                                                                              info.left.width / 2.0),
                                                                 &Size2D::new(0.0, 0.0),
                                                                 false,
-                                                                0,
+                                                                None,
                                                                 ImageFormat::RGBA8);
                             }
                         }

--- a/src/texture_cache.rs
+++ b/src/texture_cache.rs
@@ -760,11 +760,18 @@ impl TextureCache {
                 let rect = Rect::new(Point2D::new(0.0, 0.0),
                                      Size2D::new(op.outer_radius_x.to_f32_px(),
                                                  op.outer_radius_y.to_f32_px()));
-                let tessellated_rect = rect.tessellate_border_corner(
-                    &Size2D::new(op.outer_radius_x.to_f32_px(), op.outer_radius_y.to_f32_px()),
-                    &Size2D::new(op.inner_radius_x.to_f32_px(), op.inner_radius_y.to_f32_px()),
-                    BasicRotationAngle::Upright,
-                    op.index);
+                let tessellated_rect = match op.index {
+                    Some(index) => {
+                        rect.tessellate_border_corner(
+                            &Size2D::new(op.outer_radius_x.to_f32_px(),
+                                         op.outer_radius_y.to_f32_px()),
+                            &Size2D::new(op.inner_radius_x.to_f32_px(),
+                                         op.inner_radius_y.to_f32_px()),
+                            BasicRotationAngle::Upright,
+                            index)
+                    }
+                    None => rect,
+                };
                 let width = tessellated_rect.size.width.round() as u32;
                 let height = tessellated_rect.size.height.round() as u32;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -206,3 +206,10 @@ impl VaryingElement for (ColorF, Point2D<f32>) {
 pub fn rect_is_empty<N:PartialEq + Zero>(rect: &Rect<N>) -> bool {
     rect.size.width == Zero::zero() || rect.size.height == Zero::zero()
 }
+
+/// Returns true if the rectangle's width and height are both strictly positive and false
+/// otherwise.
+pub fn rect_is_well_formed_and_nonempty(rect: &Rect<f32>) -> bool {
+    rect.size.width > 0.0 && rect.size.height > 0.0
+}
+


### PR DESCRIPTION
1. Masks for large border radii were not being tessellated properly.
This commit simply switches off tessellation for them. Eventually we may
want to go back and fix this properly.

2. Border corners were being rendered correctly when 0 < border radius <
border width. We needed to do a bit more tessellation than we were. This
commit fixes that and adds a diagram to `add_border_corner` to explain
what's going on.

These commits fix the `border_radius_clip_a.html` and
`border_radius_zero_sizes_a.html` reftests.