### PR TITLE
Add support for scrolling in iframes.

### DIFF
--- a/res/quad.vs.glsl
+++ b/res/quad.vs.glsl
@@ -39,10 +39,9 @@ void main(void)
     vClipOutRect = uClipRects[int(aMisc.z)];
     vPosition = localPos.xy;
 
-    localPos.xy += offsetParams.xy;
-    localPos.xy = SnapToPixels(localPos.xy);
-
     vec4 worldPos = matrix * localPos;
+    worldPos.xy += offsetParams.xy;
+    worldPos.xy += offsetParams.zw;
     worldPos.xy = SnapToPixels(worldPos.xy);
 
     // Transform by the orthographic projection into clip space.

--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -11,8 +11,7 @@ use std::sync::Arc;
 use texture_cache::TextureCacheItem;
 use util::{self, RectVaryings};
 use webrender_traits::{FontKey, Epoch, ColorF, PipelineId};
-use webrender_traits::{ImageFormat, ScrollLayerId};
-use webrender_traits::{MixBlendMode, NativeFontHandle, DisplayItem};
+use webrender_traits::{ImageFormat, MixBlendMode, NativeFontHandle, DisplayItem};
 
 const UV_FLOAT_TO_FIXED: f32 = 65535.0;
 const COLOR_FLOAT_TO_FIXED: f32 = 255.0;
@@ -333,15 +332,18 @@ pub struct DrawCall {
 pub struct BatchInfo {
     pub matrix_palette: Vec<Matrix4>,
     pub offset_palette: Vec<OffsetParams>,
+    pub clip_rect: Option<Rect<u32>>,
     pub draw_calls: Vec<DrawCall>,
 }
 
 impl BatchInfo {
     pub fn new(matrix_palette: Vec<Matrix4>,
-               offset_palette: Vec<OffsetParams>) -> BatchInfo {
+               offset_palette: Vec<OffsetParams>,
+               clip_rect: Option<Rect<u32>>) -> BatchInfo {
         BatchInfo {
             matrix_palette: matrix_palette,
             offset_palette: offset_palette,
+            clip_rect: clip_rect,
             draw_calls: Vec::new(),
         }
     }
@@ -441,14 +443,10 @@ pub struct RenderTargetId(pub usize);
 
 #[derive(Debug, Clone)]
 pub struct StackingContextInfo {
-    pub world_origin: Point2D<f32>,
-
-    pub local_overflow: Rect<f32>,
-
-    pub world_transform: Matrix4,
-    pub world_perspective: Matrix4,
-
-    pub scroll_layer_id: ScrollLayerId,
+    pub offset_from_layer: Point2D<f32>,
+    pub local_clip_rect: Rect<f32>,
+    pub transform: Matrix4,
+    pub perspective: Matrix4,
 }
 
 #[derive(Debug)]

--- a/src/node_compiler.rs
+++ b/src/node_compiler.rs
@@ -50,9 +50,10 @@ impl NodeCompiler for AABBTreeNode {
                         let DrawListItemIndex(index) = *index;
                         let display_item = &draw_list.items[index as usize];
 
-                        let clip_rect = display_item.clip.main.intersection(&context.local_overflow);
+                        let clip_rect = display_item.clip.main.intersection(&context.local_clip_rect);
                         let clip_rect = clip_rect.and_then(|clip_rect| {
-                            let split_rect_local_space = self.split_rect.translate(&-context.world_origin);
+                            let split_rect_local_space = self.split_rect
+                                                             .translate(&-context.offset_from_layer);
                             clip_rect.intersection(&split_rect_local_space)
                         });
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -967,6 +967,22 @@ impl Renderer {
                     self.device.set_uniform_mat4_array(self.u_quad_transform_array,
                                                        &info.matrix_palette);
 
+                    if let Some(clip_rect) = info.clip_rect {
+                        debug_assert!(clip_rect.origin.y + clip_rect.size.height <= layer.layer_size.height);
+
+                        let clip_x0 = clip_rect.origin.x as gl::GLint;
+                        let clip_y0 = (layer.layer_size.height -
+                                      clip_rect.size.height -
+                                      clip_rect.origin.y) as gl::GLint;
+                        let clip_width = clip_rect.size.width as gl::GLint;
+                        let clip_height = clip_rect.size.height as gl::GLint;
+
+                        gl::scissor(self.device_pixel_ratio as gl::GLint * clip_x0,
+                                    self.device_pixel_ratio as gl::GLint * clip_y0,
+                                    self.device_pixel_ratio as gl::GLint * clip_width,
+                                    self.device_pixel_ratio as gl::GLint * clip_height);
+                    }
+
                     for draw_call in &info.draw_calls {
                         let vao_id = self.vertex_buffers[&draw_call.vertex_buffer_id].vao_id;
                         self.device.bind_vao(vao_id);


### PR DESCRIPTION
In addition to handling iframe scrolling, this changes items to be in local space relative to their scroll root.

This is very much a "work in progress" commit. There's *lots* of things that don't work:
 * Nested transforms + scroll layers
 * Render target effects + scroll layers
 * Render target effects with transforms.

However, the changes in this PR are at a stage where all (previously passing) reftests still pass, and it lays the groundwork for supporting those features listed above.