### PR TITLE
Rely on the overflow rect for layer size.

### DIFF
--- a/src/aabbtree.rs
+++ b/src/aabbtree.rs
@@ -1,7 +1,6 @@
 use euclid::{Point2D, Rect, Size2D};
 use internal_types::{CompiledNode, DrawListId, DrawListItemIndex, DrawListGroupId};
 use resource_list::ResourceList;
-use std::mem;
 use util;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -21,14 +20,6 @@ pub struct DrawListGroupSegment {
 enum TreeState {
     Building,
     Finalized,
-}
-
-#[derive(Debug)]
-struct Item {
-    rect: Rect<f32>,
-    draw_list_group_id: DrawListGroupId,
-    draw_list_id: DrawListId,
-    item_index: DrawListItemIndex,
 }
 
 pub struct AABBTreeNode {
@@ -126,50 +117,27 @@ pub struct AABBTree {
 
     work_node_indices: Vec<NodeIndex>,
 
-    pub local_bounds: Rect<f32>,
     state: TreeState,
-    items: Vec<Item>,
 }
 
 impl AABBTree {
-    pub fn new(split_size: f32) -> AABBTree {
-        AABBTree {
+    pub fn new(split_size: f32,
+               local_bounds: &Rect<f32>) -> AABBTree {
+        let mut tree = AABBTree {
             nodes: Vec::new(),
             split_size: split_size,
             work_node_indices: Vec::new(),
             state: TreeState::Building,
-            items: Vec::new(),
-            local_bounds: Rect::new(Point2D::zero(), Size2D::zero()),
-        }
+        };
+
+        let root_node = AABBTreeNode::new(local_bounds);
+        tree.nodes.push(root_node);
+
+        tree
     }
 
     pub fn finalize(&mut self) {
         debug_assert!(self.state == TreeState::Building);
-
-        let root_node = AABBTreeNode::new(&self.local_bounds);
-        self.nodes.push(root_node);
-
-        let items = mem::replace(&mut self.items, Vec::new());
-        for item in items {
-            self.find_best_nodes(NodeIndex(0), &item.rect);
-            for node_index in self.work_node_indices.drain(..) {
-                let NodeIndex(node_index) = node_index;
-                let node = &mut self.nodes[node_index as usize];
-                node.append_item(item.draw_list_group_id,
-                                 item.draw_list_id,
-                                 item.item_index,
-                                 &item.rect);
-            }
-        }
-
-        // TODO(gw): This is a total hack for reftests :(
-        if self.nodes.len() == 1 {
-            let root_node = self.node_mut(NodeIndex(0));
-            if root_node.split_rect.size.width > 0.0 && root_node.split_rect.size.height > 0.0 {
-                root_node.split_rect = root_node.split_rect.inflate(3.0, 3.0);
-            }
-        }
-
         self.state = TreeState::Finalized;
     }
 
@@ -241,13 +209,26 @@ impl AABBTree {
                   draw_list_id: DrawListId,
                   item_index: DrawListItemIndex) {
         debug_assert!(self.state == TreeState::Building);
-        self.local_bounds = self.local_bounds.union(&rect);
-        self.items.push(Item {
-            draw_list_group_id: draw_list_group_id,
-            draw_list_id: draw_list_id,
-            item_index: item_index,
-            rect: rect,
-        });
+
+        self.find_best_nodes(NodeIndex(0), &rect);
+        if self.work_node_indices.is_empty() {
+            // TODO(gw): If this happens, it it probably caused by items having
+            //           transforms that move them outside the local overflow. According
+            //           to the transforms spec, the stacking context overflow should
+            //           include transformed elements, however this isn't currently
+            //           handled by the layout code! If it's not that, this is an
+            //           unexpected condition and should be investigated!
+            println!("WARNING: insert rect {:?} outside bounds, dropped.", rect);
+        } else {
+            for node_index in self.work_node_indices.drain(..) {
+                let NodeIndex(node_index) = node_index;
+                let node = &mut self.nodes[node_index as usize];
+                node.append_item(draw_list_group_id,
+                                 draw_list_id,
+                                 item_index,
+                                 &rect);
+            }
+        }
     }
 
     fn split_if_needed(&mut self, node_index: NodeIndex) {

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -7,20 +7,24 @@ pub struct Layer {
     // TODO: Remove pub from here if possible in the future
     pub aabb_tree: AABBTree,
     pub scroll_offset: Point2D<f32>,
-    pub world_origin: Point2D<f32>,
     pub viewport_size: Size2D<f32>,
+    pub layer_size: Size2D<f32>,
+    pub world_origin: Point2D<f32>,
 }
 
 impl Layer {
     pub fn new(world_origin: Point2D<f32>,
+               layer_size: Size2D<f32>,
                viewport_size: Size2D<f32>) -> Layer {
-        let aabb_tree = AABBTree::new(1024.0);
+        let rect = Rect::new(Point2D::zero(), layer_size);
+        let aabb_tree = AABBTree::new(1024.0, &rect);
 
         Layer {
             aabb_tree: aabb_tree,
-            world_origin: world_origin,
             scroll_offset: Point2D::zero(),
             viewport_size: viewport_size,
+            world_origin: world_origin,
+            layer_size: layer_size,
         }
     }
 
@@ -46,10 +50,6 @@ impl Layer {
                               draw_list_group_id,
                               draw_list_id,
                               item_index);
-    }
-
-    pub fn size(&self) -> Size2D<f32> {
-        self.aabb_tree.local_bounds.size
     }
 
     pub fn finalize(&mut self,

--- a/tests/bug_137.html
+++ b/tests/bug_137.html
@@ -1,0 +1,25 @@
+<style>
+  body {
+    margin: 0;
+    background: red;
+    width: 100%;
+    height: 100%;
+  }
+
+  div {
+    background-image: url("data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=");
+    background-repeat: no-repeat;
+    background-size: 200px 200px;
+    position: absolute;
+    height: 30px;
+    width: 30px;
+    border: 2px solid black;
+    bottom: 0;
+    right: 0;
+  }
+
+
+
+</style>
+
+<div></div>


### PR DESCRIPTION
This is not currently correct for layers with transformed elements.

According to the spec, the overflow rect should include transformed elements, so this will need to be added/fixed in the layout code rather than WR.

Fixes #137.