### PR TITLE
Use instancing to make VBO data per-rectangle, not per-vertex.

### DIFF
--- a/res/blend.vs.glsl
+++ b/res/blend.vs.glsl
@@ -1,6 +1,6 @@
 void main(void)
 {
-	vColorTexCoord = aColorTexCoord;
-	vMaskTexCoord = aMaskTexCoord / 65535.0;
+	vColorTexCoord = aColorTexCoordRectTop.xy;
+	vMaskTexCoord = aMaskTexCoordRectTop.xy / 65535.0;
     gl_Position = uTransform * vec4(aPosition, 1.0);
 }

--- a/res/blit.vs.glsl
+++ b/res/blit.vs.glsl
@@ -1,7 +1,7 @@
 void main(void)
 {
-    vColor = aColor / 255.0;
-    vColorTexCoord = aColorTexCoord;
+    vColor = aColorRectTL / 255.0;
+    vColorTexCoord = aColorTexCoordRectTop.xy;
     vec4 pos = vec4(aPosition, 1.0);
     pos.xy = floor(pos.xy * uDevicePixelRatio + 0.5) / uDevicePixelRatio;
     gl_Position = uTransform * pos;

--- a/res/blur.vs.glsl
+++ b/res/blur.vs.glsl
@@ -1,6 +1,6 @@
 void main(void)
 {
-	vColorTexCoord = aColorTexCoord;
+	vColorTexCoord = aColorTexCoordRectTop.xy;
     vBorderPosition = aBorderPosition;
     vBlurRadius = aBlurRadius;
     vDestTextureSize = aDestTextureSize;

--- a/res/border.vs.glsl
+++ b/res/border.vs.glsl
@@ -1,6 +1,6 @@
 void main(void)
 {
-	vColor = aColor;
+	vColor = aColorRectTL;
 	vPosition = aPosition.xy;
     vBorderPosition = aBorderPosition;
     vBorderRadii = aBorderRadii;

--- a/res/box_shadow.vs.glsl
+++ b/res/box_shadow.vs.glsl
@@ -1,7 +1,7 @@
 void main(void)
 {
 	vPosition = aPosition.xy;
-	vColor = aColor;
+	vColor = aColorRectTL;
     vBorderPosition = aBorderPosition;
     vBorderRadii = aBorderRadii;
     vBlurRadius = aBlurRadius;

--- a/res/clear.vs.glsl
+++ b/res/clear.vs.glsl
@@ -1,5 +1,5 @@
 void main(void)
 {
-    vColor = aColor / 255.0;
+    vColor = aColorRectTL / 255.0;
     gl_Position = uTransform * vec4(aPosition, 1.0);
 }

--- a/res/debug_color.vs.glsl
+++ b/res/debug_color.vs.glsl
@@ -1,6 +1,6 @@
 void main(void)
 {
-    vColor = aColor;
+    vColor = aColorRectTL;
     vec4 pos = vec4(aPosition, 1.0);
     pos.xy = floor(pos.xy * uDevicePixelRatio + 0.5) / uDevicePixelRatio;
     gl_Position = uTransform * pos;

--- a/res/debug_font.vs.glsl
+++ b/res/debug_font.vs.glsl
@@ -1,7 +1,7 @@
 void main(void)
 {
-    vColor = aColor;
-    vColorTexCoord = aColorTexCoord;
+    vColor = aColorRectTL;
+    vColorTexCoord = aColorTexCoordRectTop.xy;
     vec4 pos = vec4(aPosition, 1.0);
     pos.xy = floor(pos.xy * uDevicePixelRatio + 0.5) / uDevicePixelRatio;
     gl_Position = uTransform * pos;

--- a/res/es2_common.vs.glsl
+++ b/res/es2_common.vs.glsl
@@ -13,15 +13,26 @@ uniform float uDevicePixelRatio;
 uniform vec4 uTileParams[64];
 
 attribute vec3 aPosition;
-attribute vec4 aColor;
-attribute vec2 aColorTexCoord;
-attribute vec2 aMaskTexCoord;
+attribute vec4 aPositionRect;  // Width can be negative to flip horizontally (for border corners).
+attribute vec4 aColorRectTL;
+attribute vec4 aColorRectTR;
+attribute vec4 aColorRectBR;
+attribute vec4 aColorRectBL;
+attribute vec4 aColorTexCoordRectTop;
+attribute vec4 aColorTexCoordRectBottom;
+attribute vec4 aMaskTexCoordRectTop;
+attribute vec4 aMaskTexCoordRectBottom;
 attribute vec4 aBorderPosition;
 attribute vec4 aBorderRadii;
 attribute vec2 aSourceTextureSize;
 attribute vec2 aDestTextureSize;
 attribute float aBlurRadius;
-attribute vec4 aMisc;   // x = matrix index; w = tile params index
+// x = matrix index; y = clip-in rect; z = clip-out rect; w = tile params index.
+//
+// A negative w value activates border corner mode. In this mode, the TR and BL colors are ignored,
+// the color of the top left corner applies to all vertices of the top left triangle, and the color
+// of the bottom right corner applies to all vertices of the bottom right triangle.
+attribute vec4 aMisc;
 
 varying vec2 vPosition;
 varying vec4 vColor;
@@ -35,3 +46,13 @@ varying float vBlurRadius;
 varying vec4 vTileParams;
 varying vec4 vClipInRect;
 varying vec4 vClipOutRect;
+
+int Bottom7Bits(int value) {
+    return value % 0x80;
+}
+
+bool IsBottomTriangle() {
+    // FIXME(pcwalton): No gl_VertexID in OpenGL ES 2. We'll need some extra data.
+    return false;
+}
+

--- a/res/filter.vs.glsl
+++ b/res/filter.vs.glsl
@@ -1,7 +1,7 @@
 void main(void)
 {
-	vColorTexCoord = aColorTexCoord;
-	vMaskTexCoord = aMaskTexCoord;
+	vColorTexCoord = aColorTexCoordRectTop.xy;
+	vMaskTexCoord = aMaskTexCoordRectTop.xy;
     gl_Position = uTransform * vec4(aPosition, 1.0);
 }
 

--- a/res/gl3_common.vs.glsl
+++ b/res/gl3_common.vs.glsl
@@ -13,15 +13,26 @@ uniform float uDevicePixelRatio;
 uniform vec4 uTileParams[64];
 
 in vec3 aPosition;
-in vec4 aColor;
-in vec2 aColorTexCoord;
-in vec2 aMaskTexCoord;
+in vec4 aPositionRect;  // Width can be negative to flip horizontally (for border corners).
+in vec4 aColorRectTL;
+in vec4 aColorRectTR;
+in vec4 aColorRectBR;
+in vec4 aColorRectBL;
+in vec4 aColorTexCoordRectTop;
+in vec4 aColorTexCoordRectBottom;
+in vec4 aMaskTexCoordRectTop;
+in vec4 aMaskTexCoordRectBottom;
 in vec4 aBorderPosition;
 in vec4 aBorderRadii;
 in vec2 aSourceTextureSize;
 in vec2 aDestTextureSize;
 in float aBlurRadius;
-in vec4 aMisc;  // x = matrix index; w = tile params index
+// x = matrix index; y = clip-in rect; z = clip-out rect; w = tile params index.
+//
+// A negative w value activates border corner mode. In this mode, the TR and BL colors are ignored,
+// the color of the top left corner applies to all vertices of the top left triangle, and the color
+// of the bottom right corner applies to all vertices of the bottom right triangle.
+in vec4 aMisc;
 
 out vec2 vPosition;
 out vec4 vColor;
@@ -35,3 +46,12 @@ out float vBlurRadius;
 out vec4 vTileParams;
 out vec4 vClipInRect;
 out vec4 vClipOutRect;
+
+int Bottom7Bits(int value) {
+    return value & 0x7f;
+}
+
+bool IsBottomTriangle() {
+    return gl_VertexID > 2;
+}
+

--- a/src/batch_builder.rs
+++ b/src/batch_builder.rs
@@ -3,11 +3,9 @@ use batch::{BatchBuilder, TileParams};
 use device::TextureId;
 use euclid::{Rect, Point2D, Size2D};
 use fnv::FnvHasher;
-use internal_types::{RectColors, RectPolygon};
-use internal_types::{RectUv, BorderRadiusRasterOp, RasterItem};
-use internal_types::{GlyphKey, PackedVertex};
-use internal_types::{AxisDirection, Primitive};
-use internal_types::{BasicRotationAngle, BoxShadowRasterOp, RectSide};
+use internal_types::{AxisDirection, BasicRotationAngle, BorderRadiusRasterOp, BoxShadowRasterOp};
+use internal_types::{GlyphKey, PackedVertexColorMode, RasterItem, RectColors, RectPolygon};
+use internal_types::{RectSide, RectUv};
 use renderer::BLUR_INFLATION_FACTOR;
 use resource_cache::ResourceCache;
 use std::collections::HashMap;
@@ -46,32 +44,13 @@ impl<'a> BatchBuilder<'a> {
             return
         }
 
-        let mut vertices = [
-            PackedVertex::from_points(&pos_rect.origin,
-                                      &colors[0],
-                                      &uv_rect.top_left,
-                                      &muv_rect.top_left),
-
-            PackedVertex::from_points(&pos_rect.top_right(),
-                                      &colors[1],
-                                      &uv_rect.top_right,
-                                      &muv_rect.top_right),
-
-            PackedVertex::from_points(&pos_rect.bottom_left(),
-                                      &colors[3],
-                                      &uv_rect.bottom_left,
-                                      &muv_rect.bottom_left),
-
-            PackedVertex::from_points(&pos_rect.bottom_right(),
-                                      &colors[2],
-                                      &uv_rect.bottom_right,
-                                      &muv_rect.bottom_right),
-        ];
-
-        self.add_draw_item(color_texture_id,
+        self.add_rectangle(color_texture_id,
                            mask_texture_id,
-                           Primitive::Rectangles,
-                           &mut vertices,
+                           pos_rect,
+                           uv_rect,
+                           muv_rect,
+                           colors,
+                           PackedVertexColorMode::Gradient,
                            tile_params);
     }
 
@@ -384,47 +363,18 @@ impl<'a> BatchBuilder<'a> {
             }
         }
 
-        let mut vertex_buffer = Vec::new();
         for (texture_id, rect_buffer) in text_batches {
-            vertex_buffer.clear();
-
             for rect in rect_buffer {
-                let x0 = rect.pos.origin.x;
-                let y0 = rect.pos.origin.y;
-                let x1 = x0 + rect.pos.size.width;
-                let y1 = y0 + rect.pos.size.height;
-
-                vertex_buffer.push(PackedVertex::from_components(
-                        x0, y0,
-                        color,
-                        rect.varyings.top_left.x, rect.varyings.top_left.y,
-                        dummy_mask_image.uv_rect.top_left.x,
-                        dummy_mask_image.uv_rect.top_left.y));
-                vertex_buffer.push(PackedVertex::from_components(
-                        x1, y0,
-                        color,
-                        rect.varyings.top_right.x, rect.varyings.top_right.y,
-                        dummy_mask_image.uv_rect.top_right.x,
-                        dummy_mask_image.uv_rect.top_right.y));
-                vertex_buffer.push(PackedVertex::from_components(
-                        x0, y1,
-                        color,
-                        rect.varyings.bottom_left.x, rect.varyings.bottom_left.y,
-                        dummy_mask_image.uv_rect.bottom_left.x,
-                        dummy_mask_image.uv_rect.bottom_left.y));
-                vertex_buffer.push(PackedVertex::from_components(
-                        x1, y1,
-                        color,
-                        rect.varyings.bottom_right.x, rect.varyings.bottom_right.y,
-                        dummy_mask_image.uv_rect.bottom_right.x,
-                        dummy_mask_image.uv_rect.bottom_right.y));
+                self.add_rectangle(texture_id,
+                                   dummy_mask_image.texture_id,
+                                   &rect.pos,
+                                   &rect.varyings,
+                                   &dummy_mask_image.uv_rect,
+                                   &[*color, *color, *color, *color],
+                                   PackedVertexColorMode::Gradient,
+                                   None);
             }
 
-            self.add_draw_item(texture_id,
-                               dummy_mask_image.texture_id,
-                               Primitive::Rectangles,
-                               &mut vertex_buffer,
-                               None);
         }
     }
 
@@ -551,32 +501,14 @@ impl<'a> BatchBuilder<'a> {
             //           To fix this, use a bit of trigonometry to supply the rectangles as
             //           axis-aligned, and then the complex clipping will just work!
 
-            let mut vertices = [
-                PackedVertex::from_points(&Point2D::new(x0, y0),
-                                          &color0,
-                                          &white_image.uv_rect.top_left,
-                                          &dummy_mask_image.uv_rect.top_left),
-
-                PackedVertex::from_points(&Point2D::new(x1, y1),
-                                          &color1,
-                                          &white_image.uv_rect.top_left,
-                                          &dummy_mask_image.uv_rect.top_left),
-
-                PackedVertex::from_points(&Point2D::new(x3, y3),
-                                          &color0,
-                                          &white_image.uv_rect.top_left,
-                                          &dummy_mask_image.uv_rect.top_left),
-
-                PackedVertex::from_points(&Point2D::new(x2, y2),
-                                          &color1,
-                                          &white_image.uv_rect.top_left,
-                                          &dummy_mask_image.uv_rect.top_left),
-            ];
-
-            self.add_draw_item(white_image.texture_id,
+            let rect = Rect::new(Point2D::new(x0, y0), Size2D::new(x3 - x0, y3 - y0));
+            self.add_rectangle(white_image.texture_id,
                                dummy_mask_image.texture_id,
-                               Primitive::Rectangles,
-                               &mut vertices,
+                               &rect,
+                               &white_image.uv_rect,
+                               &dummy_mask_image.uv_rect,
+                               &[*color0, *color1, *color0, *color1],
+                               PackedVertexColorMode::Gradient,
                                None);
         }
     }
@@ -1409,59 +1341,58 @@ impl<'a> BatchBuilder<'a> {
 
         let v0;
         let v1;
-        let muv0;
-        let muv1;
-        let muv2;
-        let muv3;
+        let muv;
         match rotation_angle {
             BasicRotationAngle::Upright => {
                 v0 = rect_pos_uv.pos.origin;
                 v1 = rect_pos_uv.pos.bottom_right();
-                muv0 = rect_pos_uv.varyings.top_left;
-                muv1 = rect_pos_uv.varyings.top_right;
-                muv2 = rect_pos_uv.varyings.bottom_right;
-                muv3 = rect_pos_uv.varyings.bottom_left;
+                muv = RectUv {
+                    top_left: rect_pos_uv.varyings.top_left,
+                    top_right: rect_pos_uv.varyings.top_right,
+                    bottom_right: rect_pos_uv.varyings.bottom_right,
+                    bottom_left: rect_pos_uv.varyings.bottom_left,
+                }
             }
             BasicRotationAngle::Clockwise90 => {
                 v0 = rect_pos_uv.pos.top_right();
                 v1 = rect_pos_uv.pos.bottom_left();
-                muv0 = rect_pos_uv.varyings.top_right;
-                muv1 = rect_pos_uv.varyings.top_left;
-                muv2 = rect_pos_uv.varyings.bottom_left;
-                muv3 = rect_pos_uv.varyings.bottom_right;
+                muv = RectUv {
+                    top_left: rect_pos_uv.varyings.top_right,
+                    top_right: rect_pos_uv.varyings.top_left,
+                    bottom_right: rect_pos_uv.varyings.bottom_left,
+                    bottom_left: rect_pos_uv.varyings.bottom_right,
+                }
             }
             BasicRotationAngle::Clockwise180 => {
                 v0 = rect_pos_uv.pos.bottom_right();
                 v1 = rect_pos_uv.pos.origin;
-                muv0 = rect_pos_uv.varyings.bottom_right;
-                muv1 = rect_pos_uv.varyings.bottom_left;
-                muv2 = rect_pos_uv.varyings.top_left;
-                muv3 = rect_pos_uv.varyings.top_right;
+                muv = RectUv {
+                    top_left: rect_pos_uv.varyings.bottom_right,
+                    top_right: rect_pos_uv.varyings.bottom_left,
+                    bottom_right: rect_pos_uv.varyings.top_left,
+                    bottom_left: rect_pos_uv.varyings.top_right,
+                }
             }
             BasicRotationAngle::Clockwise270 => {
                 v0 = rect_pos_uv.pos.bottom_left();
                 v1 = rect_pos_uv.pos.top_right();
-                muv0 = rect_pos_uv.varyings.bottom_left;
-                muv1 = rect_pos_uv.varyings.bottom_right;
-                muv2 = rect_pos_uv.varyings.top_right;
-                muv3 = rect_pos_uv.varyings.top_left;
+                muv = RectUv {
+                    top_left: rect_pos_uv.varyings.bottom_left,
+                    top_right: rect_pos_uv.varyings.bottom_right,
+                    bottom_right: rect_pos_uv.varyings.top_right,
+                    bottom_left: rect_pos_uv.varyings.top_left,
+                }
             }
         }
 
-        let mut vertices = [
-            PackedVertex::from_components(v0.x, v0.y, color0, 0.0, 0.0, muv0.x, muv0.y),
-            PackedVertex::from_components(v1.x, v1.y, color0, 0.0, 0.0, muv2.x, muv2.y),
-            PackedVertex::from_components(v0.x, v1.y, color0, 0.0, 0.0, muv3.x, muv3.y),
-            PackedVertex::from_components(v0.x, v0.y, color1, 0.0, 0.0, muv0.x, muv0.y),
-            PackedVertex::from_components(v1.x, v0.y, color1, 0.0, 0.0, muv1.x, muv1.y),
-            PackedVertex::from_components(v1.x, v1.y, color1, 0.0, 0.0, muv2.x, muv2.y),
-        ];
-
-        self.add_draw_item(white_image.texture_id,
+        self.add_rectangle(white_image.texture_id,
                            mask_image.texture_id,
-                           Primitive::Triangles,
-                           &mut vertices,
-                           None);
+                           &Rect::new(v0, Size2D::new(v1.x - v0.x, v1.y - v0.y)),
+                           &RectUv::zero(),
+                           &muv,
+                           &[*color1, *color1, *color0, *color0],
+                           PackedVertexColorMode::BorderCorner,
+                           None)
     }
 
     fn add_color_image_rectangle(&mut self,

--- a/src/debug_render.rs
+++ b/src/debug_render.rs
@@ -28,9 +28,9 @@ impl DebugRenderer {
         let font_program_id = device.create_program("debug_font");
         let color_program_id = device.create_program("debug_color");
 
-        let font_vao = device.create_vao(VertexFormat::DebugFont);
-        let line_vao = device.create_vao(VertexFormat::DebugColor);
-        let tri_vao = device.create_vao(VertexFormat::DebugColor);
+        let font_vao = device.create_vao(VertexFormat::DebugFont, None);
+        let line_vao = device.create_vao(VertexFormat::DebugColor, None);
+        let tri_vao = device.create_vao(VertexFormat::DebugColor, None);
 
         let font_texture_id = device.create_texture_ids(1)[0];
         device.init_texture(font_texture_id,
@@ -179,16 +179,16 @@ impl DebugRenderer {
             device.update_vao_indices(self.tri_vao,
                                       &self.tri_indices,
                                       VertexUsageHint::Dynamic);
-            device.update_vao_vertices(self.tri_vao,
-                                       &self.tri_vertices,
-                                       VertexUsageHint::Dynamic);
+            device.update_vao_main_vertices(self.tri_vao,
+                                            &self.tri_vertices,
+                                            VertexUsageHint::Dynamic);
             device.draw_triangles_u32(0, self.tri_indices.len() as gl::GLint);
 
             // Lines
             device.bind_vao(self.line_vao);
-            device.update_vao_vertices(self.line_vao,
-                                       &self.line_vertices,
-                                       VertexUsageHint::Dynamic);
+            device.update_vao_main_vertices(self.line_vao,
+                                            &self.line_vertices,
+                                            VertexUsageHint::Dynamic);
             device.draw_nonindexed_lines(0, self.line_vertices.len() as gl::GLint);
 
             // Glyphs
@@ -198,9 +198,9 @@ impl DebugRenderer {
             device.update_vao_indices(self.font_vao,
                                       &self.font_indices,
                                       VertexUsageHint::Dynamic);
-            device.update_vao_vertices(self.font_vao,
-                                       &self.font_vertices,
-                                       VertexUsageHint::Dynamic);
+            device.update_vao_main_vertices(self.font_vao,
+                                            &self.font_vertices,
+                                            VertexUsageHint::Dynamic);
             device.draw_triangles_u32(0, self.font_indices.len() as gl::GLint);
         }
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -194,8 +194,8 @@ impl RenderTarget {
                                         vertex_buffer_id: vertex_buffer_id,
                                         color_texture_id: batch.color_texture_id,
                                         mask_texture_id: batch.mask_texture_id,
-                                        first_vertex: batch.first_vertex,
-                                        index_count: batch.index_count,
+                                        first_instance: batch.first_instance,
+                                        instance_count: batch.instance_count,
                                     });
                                 }
                             }
@@ -1123,8 +1123,7 @@ impl Frame {
 
                         self.pending_updates.push(BatchUpdate {
                             id: vertex_buffer.id,
-                            op: BatchUpdateOp::Create(vertex_buffer.vertices,
-                                                      vertex_buffer.indices),
+                            op: BatchUpdateOp::Create(vertex_buffer.vertices),
                         });
 
                         compiled_node.vertex_buffer_id = Some(vertex_buffer.id);


### PR DESCRIPTION
Doing this slightly reduces the size of our VBOs and opens the door to
performing clipping in the vertex shader. With more clever
optimizations, we should be able to shrink the VBO size down even
further.

This patch includes a fallback for OpenGL ES 2.1. Unfortunately, this
fallback increases the size of the VBOs significantly. This could be
mitigated in the future, though not without effort.