### PR TITLE
Process clip-in rectangles in the vertex shader, not in the fragment shader.

### DIFF
--- a/res/gl3_common.vs.glsl
+++ b/res/gl3_common.vs.glsl
@@ -44,7 +44,6 @@ out vec2 vDestTextureSize;
 out vec2 vSourceTextureSize;
 out float vBlurRadius;
 out vec4 vTileParams;
-out vec4 vClipInRect;
 out vec4 vClipOutRect;
 
 int Bottom7Bits(int value) {

--- a/res/quad.fs.glsl
+++ b/res/quad.fs.glsl
@@ -8,11 +8,6 @@ bool PointInRect(vec2 p, vec2 p0, vec2 p1)
 
 void main(void)
 {
-    // Clip in rect
-    if (!PointInRect(vPosition, vClipInRect.xy, vClipInRect.zw)) {
-        discard;
-    }
-
     // Clip out rect
     if (PointInRect(vPosition, vClipOutRect.xy, vClipOutRect.zw)) {
         discard;


### PR DESCRIPTION
60% improvement in GPU time on Wikipedia.