### PR TITLE
Reimplement arbitrary rotation angles for linear gradients by clipping in the fragment shader.

### DIFF
--- a/res/gl3_common.vs.glsl
+++ b/res/gl3_common.vs.glsl
@@ -45,6 +45,7 @@ out vec2 vDestTextureSize;
 out vec2 vSourceTextureSize;
 out float vBlurRadius;
 out vec4 vTileParams;
+out vec4 vClipInRect;
 out vec4 vClipOutRect;
 
 int Bottom7Bits(int value) {

--- a/res/quad.fs.glsl
+++ b/res/quad.fs.glsl
@@ -8,8 +8,13 @@ bool PointInRect(vec2 p, vec2 p0, vec2 p1)
 
 void main(void)
 {
-    // Clip out rect
+    // Clip out.
     if (PointInRect(vPosition, vClipOutRect.xy, vClipOutRect.zw)) {
+        discard;
+    }
+
+    // Clip in.
+    if (vClipInRect != vec4(0.0) && !PointInRect(vPosition, vClipInRect.xy, vClipInRect.zw)) {
         discard;
     }
 

--- a/res/quad.vs.glsl
+++ b/res/quad.vs.glsl
@@ -70,11 +70,31 @@ void main(void)
         }
     }
 
-    // Clip and compute varyings.
-    localPos.xy = clamp(localPos.xy, clipInRect.xy, clipInRect.zw);
     vec2 localST = (localPos.xy - rect_origin) / rect_size;
+
+    // Rotate or clip as necessary. If there is no rotation, we can clip here in the vertex shader
+    // and save a whole bunch of fragment shader invocations. If there is a rotation, we fall back
+    // to FS clipping.
+    //
+    // The rotation angle is encoded as a negative bottom left u coordinate. (uv coordinates should
+    // always be nonnegative normally, and gradients don't use color textures, so this is fine.)
+    vec4 colorTexCoordRectBottom = aColorTexCoordRectBottom;
+    if (colorTexCoordRectBottom.z < 0.0) {
+        float angle = -colorTexCoordRectBottom.z;
+        vec2 center = rect_origin + rect_size / 2.0;
+        vec2 translatedPos = localPos.xy - center;
+        localPos.xy = vec2(translatedPos.x * cos(angle) - translatedPos.y * sin(angle),
+                           translatedPos.x * sin(angle) + translatedPos.y * cos(angle)) + center;
+        colorTexCoordRectBottom.z = aColorTexCoordRectTop.x;
+        vClipInRect = clipInRect;
+    } else {
+        localPos.x = clamp(localPos.x, clipInRect.x, clipInRect.z);
+        localPos.y = clamp(localPos.y, clipInRect.y, clipInRect.w);
+        vClipInRect = vec4(0.0);
+    }
+
     vColorTexCoord = Bilerp2(aColorTexCoordRectTop.xy, aColorTexCoordRectTop.zw,
-                             aColorTexCoordRectBottom.xy, aColorTexCoordRectBottom.zw,
+                             colorTexCoordRectBottom.xy, colorTexCoordRectBottom.zw,
                              localST);
     vMaskTexCoord = Bilerp2(aMaskTexCoordRectTop.xy, aMaskTexCoordRectTop.zw,
                             aMaskTexCoordRectBottom.xy, aMaskTexCoordRectBottom.zw,

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -252,6 +252,10 @@ impl<'a> BatchBuilder<'a> {
         self.current_matrix_index += 1;
     }
 
+    pub fn clip_in_rect(&self) -> Rect<f32> {
+        self.cached_clip_in_rect.unwrap_or(MAX_RECT)
+    }
+
     // TODO(gw): This is really inefficient to call this every push/pop...
     fn update_clip_in_rect(&mut self) {
         self.cached_clip_in_rect = Some(MAX_RECT);

--- a/src/node_compiler.rs
+++ b/src/node_compiler.rs
@@ -65,6 +65,8 @@ impl NodeCompiler for AABBTreeNode {
                             builder.push_clip_in_rect(clip_rect);
                             builder.push_complex_clip(&display_item.clip.complex);
 
+                            println!("clip rect={:?}", clip_rect);
+
                             match display_item.item {
                                 SpecificDisplayItem::WebGL(ref info) => {
                                     builder.add_webgl_rectangle(&display_item.rect,

--- a/src/util.rs
+++ b/src/util.rs
@@ -190,3 +190,12 @@ pub fn rect_center(rect: &Rect<f32>) -> Point2D<f32> {
     Point2D::new(rect.origin.x + rect.size.width / 2.0, rect.origin.y + rect.size.height / 2.0)
 }
 
+pub fn distance(a: &Point2D<f32>, b: &Point2D<f32>) -> f32 {
+    let (x, y) = (b.x - a.x, b.y - a.y);
+    (x * x + y * y).sqrt()
+}
+
+pub fn lerp_points(a: &Point2D<f32>, b: &Point2D<f32>, t: f32) -> Point2D<f32> {
+    Point2D::new(lerp(a.x, b.x, t), lerp(a.y, b.y, t))
+}
+


### PR DESCRIPTION
This reintroduces the clip-in rect in the FS. Since we'll need it anyway
when we have arbitrary matrix/clip stacks, this seems harmless.

Color strips for non-axis-aligned linear gradients are submitted as
axis-aligned rects centered at the appropriate point, just as
axis-aligned ones are. However, we reuse one of the vertex fields to
store the rotation angle. The vertex shader detects this condition,
rotates the rectangle around its midpoint, and passes the clip rect on
to the fragment shader.

Additionally, this patch eliminates the ugly (-10000,10000) spans for
linear gradient strips that we had before. It was necessary to tighten
this up in order to avoid needless fragment shader invocations in the
non-axis-aligned case, so I went ahead and fixed it everywhere.

Closes #161.