### PR TITLE
Make batch updates and delivery of a new frame into an atomic operation.

### DIFF
--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -558,9 +558,8 @@ impl RendererFrame {
 
 pub enum ResultMsg {
     UpdateTextureCache(TextureUpdateList),
-    UpdateBatches(BatchUpdateList),
     RefreshShader(PathBuf),
-    NewFrame(RendererFrame, BackendProfileCounters),
+    NewFrame(RendererFrame, BatchUpdateList, BackendProfileCounters),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/render_backend.rs
+++ b/src/render_backend.rs
@@ -294,18 +294,14 @@ impl RenderBackend {
             self.result_tx.send(ResultMsg::UpdateTextureCache(pending_update)).unwrap();
         }
 
-        let pending_update = self.frame.pending_updates();
-        if pending_update.updates.len() > 0 {
-            self.result_tx.send(ResultMsg::UpdateBatches(pending_update)).unwrap();
-        }
-
         frame
     }
 
     fn publish_frame(&mut self,
                      frame: RendererFrame,
                      profile_counters: &mut BackendProfileCounters) {
-        let msg = ResultMsg::NewFrame(frame, profile_counters.clone());
+        let pending_updates = self.frame.pending_updates();
+        let msg = ResultMsg::NewFrame(frame, pending_updates, profile_counters.clone());
         self.result_tx.send(msg).unwrap();
         profile_counters.reset();
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -302,11 +302,9 @@ impl Renderer {
                 ResultMsg::UpdateTextureCache(update_list) => {
                     self.pending_texture_updates.push(update_list);
                 }
-                ResultMsg::UpdateBatches(update_list) => {
-                    self.pending_batch_updates.push(update_list);
-                }
-                ResultMsg::NewFrame(frame, profile_counters) => {
+                ResultMsg::NewFrame(frame, update_list, profile_counters) => {
                     self.backend_profile_counters = profile_counters;
+                    self.pending_batch_updates.push(update_list);
                     self.current_frame = Some(frame);
                 }
                 ResultMsg::RefreshShader(path) => {


### PR DESCRIPTION
Before this patch, there was a chance that batch updates could be
delivered to the compositor thread (destroying old resources) and then a
render operation could be invoked before arrival of the new frame. This
would cause the compositor thread to attempt to render frame N with the
resources of frame N+1, which would usually crash.

Closes #160.