### PR TITLE
Correctly allocate render target space during stacking context traversal.

### DIFF
--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -488,12 +488,13 @@ impl BatchInfo {
 pub struct CompositeBatchJob {
     pub rect: Rect<i32>,
     pub transform: Matrix4,
-    pub render_target_index: RenderTargetIndex,
+    pub child_layer_index: ChildLayerIndex,
 }
 
 #[derive(Debug, Clone)]
 pub struct CompositeBatchInfo {
     pub operation: CompositionOp,
+    pub texture_id: TextureId,
     pub jobs: Vec<CompositeBatchJob>,
 }
 
@@ -505,38 +506,33 @@ pub enum DrawCommand {
 }
 
 #[derive(Clone, Copy, Debug, Ord, PartialOrd, PartialEq, Eq, Hash)]
-pub struct RenderTargetIndex(pub u32);
-
-#[derive(Debug)]
-pub struct DrawTargetInfo {
-    pub texture_id: TextureId,
-    pub size: Size2D<u32>,
-}
+pub struct ChildLayerIndex(pub u32);
 
 #[derive(Debug)]
 pub struct DrawLayer {
     // This layer
     pub commands: Vec<DrawCommand>,
-    pub layer_origin: Point2D<f32>,
-    pub layer_size: Size2D<f32>,
+    pub texture_id: Option<TextureId>,
+    pub origin: Point2D<f32>,
+    pub size: Size2D<f32>,
 
     // Children
-    pub child_target: Option<DrawTargetInfo>,
     pub child_layers: Vec<DrawLayer>,
 }
 
 impl DrawLayer {
-    pub fn new(child_target: Option<DrawTargetInfo>,
-               child_layers: Vec<DrawLayer>,
+    pub fn new(origin: Point2D<f32>,
+               size: Size2D<f32>,
+               texture_id: Option<TextureId>,
                commands: Vec<DrawCommand>,
-               size: Size2D<f32>)
+               child_layers: Vec<DrawLayer>)
                -> DrawLayer {
         DrawLayer {
-            child_target: child_target,
+            origin: origin,
+            size: size,
+            texture_id: texture_id,
             commands: commands,
             child_layers: child_layers,
-            layer_origin: Point2D::zero(),
-            layer_size: size,
         }
     }
 }

--- a/src/render_backend.rs
+++ b/src/render_backend.rs
@@ -236,7 +236,8 @@ impl RenderBackend {
 
         self.frame.create(&self.scene,
                           &mut self.resource_cache,
-                          &mut new_pipeline_sizes);
+                          &mut new_pipeline_sizes,
+                          self.device_pixel_ratio);
 
         let mut updated_pipeline_sizes = HashMap::new();
 

--- a/src/texture_cache.rs
+++ b/src/texture_cache.rs
@@ -85,6 +85,10 @@ impl TexturePage {
         page
     }
 
+    pub fn texture_id(&self) -> TextureId {
+        self.texture_id
+    }
+
     fn find_index_of_best_rect_in_bin(&self, bin: FreeListBin, requested_dimensions: &Size2D<u32>)
                                       -> Option<FreeListIndex> {
         let mut smallest_index_and_area = None;


### PR DESCRIPTION
Fixes #157.