### PR TITLE
Add support for GPU generated raster ops to have texture atlas border edges.

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1,9 +1,10 @@
-use device::{ProgramId, TextureId};
+use device::{ProgramId, TextureId, TextureFilter};
 use euclid::{Point2D, Rect, Size2D};
 use internal_types::{MAX_RECT, AxisDirection, PackedVertexColorMode, PackedVertexForQuad};
 use internal_types::{PackedVertexForTextureCacheUpdate, RectUv, DevicePixel};
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
+use texture_cache::{BorderType, TexturePage};
 use webrender_traits::{ColorF, ComplexClipRegion};
 
 pub const MAX_MATRICES_PER_BATCH: usize = 32;
@@ -366,73 +367,97 @@ impl<'a> BatchBuilder<'a> {
     }
 }
 
+// Information needed to blit an item from a raster op batch target to final destination.
+pub struct BlitJob {
+    pub dest_texture_id: TextureId,
+    pub size: Size2D<u32>,
+    pub src_origin: Point2D<u32>,
+    pub dest_origin: Point2D<u32>,
+    pub border_type: BorderType,
+}
+
 /// A batch for raster jobs.
 pub struct RasterBatch {
     pub program_id: ProgramId,
     pub blur_direction: Option<AxisDirection>,
-    pub dest_texture_id: TextureId,
     pub color_texture_id: TextureId,
     pub vertices: Vec<PackedVertexForTextureCacheUpdate>,
     pub indices: Vec<u16>,
+    pub page_allocator: TexturePage,
+    pub dest_texture_id: TextureId,
+    pub blit_jobs: Vec<BlitJob>,
 }
 
 impl RasterBatch {
-    pub fn new(program_id: ProgramId,
+    pub fn new(target_texture_id: TextureId,
+               target_texture_size: u32,
+               program_id: ProgramId,
                blur_direction: Option<AxisDirection>,
-               dest_texture_id: TextureId,
-               color_texture_id: TextureId)
+               color_texture_id: TextureId,
+               dest_texture_id: TextureId)
                -> RasterBatch {
-        debug_assert!(dest_texture_id != color_texture_id);
         RasterBatch {
             program_id: program_id,
             blur_direction: blur_direction,
-            dest_texture_id: dest_texture_id,
             color_texture_id: color_texture_id,
+            dest_texture_id: dest_texture_id,
             vertices: Vec::new(),
             indices: Vec::new(),
+            page_allocator: TexturePage::new(target_texture_id, target_texture_size),
+            blit_jobs: Vec::new(),
         }
     }
 
-    pub fn can_add_to_batch(&self,
-                            dest_texture_id: TextureId,
-                            color_texture_id: TextureId,
-                            program_id: ProgramId,
-                            blur_direction: Option<AxisDirection>)
-                            -> bool {
+    pub fn add_rect_if_possible<F>(&mut self,
+                                   dest_texture_id: TextureId,
+                                   color_texture_id: TextureId,
+                                   program_id: ProgramId,
+                                   blur_direction: Option<AxisDirection>,
+                                   dest_rect: &Rect<u32>,
+                                   border_type: BorderType,
+                                   f: &F) -> bool
+                                   where F: Fn(&Rect<f32>) -> [PackedVertexForTextureCacheUpdate; 4] {
+        // TODO(gw): How to detect / handle if border type is single pixel but not in an atlas!?
+
         let batch_ok = program_id == self.program_id &&
             blur_direction == self.blur_direction &&
-            dest_texture_id == self.dest_texture_id &&
-            color_texture_id == self.color_texture_id;
-/*
-        println!("batch ok? {:?} program_id={:?}/{:?} blur_direction={:?}/{:?} \
-                  dest_texture_id {:?}/{:?} color_texture_id={:?}/{:?}",
-                 batch_ok,
-                 program_id, self.program_id,
-                 blur_direction, self.blur_direction,
-                 dest_texture_id, self.dest_texture_id,
-                 color_texture_id, self.color_texture_id);
-*/
-        batch_ok
-    }
+            color_texture_id == self.color_texture_id &&
+            dest_texture_id == self.dest_texture_id;
 
-    pub fn add_draw_item(&mut self,
-                         dest_texture_id: TextureId,
-                         color_texture_id: TextureId,
-                         vertices: &[PackedVertexForTextureCacheUpdate]) {
-        debug_assert!(dest_texture_id == self.dest_texture_id);
-        debug_assert!(color_texture_id == self.color_texture_id);
+        if batch_ok {
+            let origin = self.page_allocator.allocate(&dest_rect.size, TextureFilter::Linear);
 
-        for i in (0..vertices.len()).step_by(4) {
-            let index_offset = self.vertices.len();
-            let index_base = (index_offset + i) as u16;
-            self.indices.push(index_base + 0);
-            self.indices.push(index_base + 1);
-            self.indices.push(index_base + 2);
-            self.indices.push(index_base + 2);
-            self.indices.push(index_base + 3);
-            self.indices.push(index_base + 1);
+            if let Some(origin) = origin {
+                let vertices = f(&Rect::new(Point2D::new(origin.x as f32,
+                                                         origin.y as f32),
+                                            Size2D::new(dest_rect.size.width as f32,
+                                                        dest_rect.size.height as f32)));
+
+                for i in (0..vertices.len()).step_by(4) {
+                    let index_offset = self.vertices.len();
+                    let index_base = (index_offset + i) as u16;
+                    self.indices.push(index_base + 0);
+                    self.indices.push(index_base + 1);
+                    self.indices.push(index_base + 2);
+                    self.indices.push(index_base + 2);
+                    self.indices.push(index_base + 3);
+                    self.indices.push(index_base + 1);
+                }
+
+                self.vertices.extend_from_slice(&vertices);
+
+                self.blit_jobs.push(BlitJob {
+                    dest_texture_id: dest_texture_id,
+                    size: dest_rect.size,
+                    dest_origin: dest_rect.origin,
+                    src_origin: origin,
+                    border_type: border_type,
+                });
+
+                return true;
+            }
         }
 
-        self.vertices.extend_from_slice(vertices);
+        false
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -1379,13 +1379,13 @@ impl Device {
                              data);
     }
 
-    fn update_texture(&mut self,
-                      texture_id: TextureId,
-                      x0: u32,
-                      y0: u32,
-                      width: u32,
-                      height: u32,
-                      data: &[u8]) {
+    pub fn update_texture(&mut self,
+                          texture_id: TextureId,
+                          x0: u32,
+                          y0: u32,
+                          width: u32,
+                          height: u32,
+                          data: &[u8]) {
         debug_assert!(self.inside_frame);
 
         let (gl_format, bpp) = match self.textures.get(&texture_id).unwrap().format {
@@ -1406,36 +1406,23 @@ impl Device {
                                          data);
     }
 
-    pub fn update_texture_for_noncomposite_operation(&mut self,
-                                                     texture_id: TextureId,
-                                                     x0: u32,
-                                                     y0: u32,
-                                                     width: u32,
-                                                     height: u32,
-                                                     data: &[u8]) {
-        self.update_texture(texture_id, x0, y0, width, height, data)
-    }
-
-    fn read_framebuffer_rect_for_2d_texture(&mut self,
-                                            texture_id: TextureId,
-                                            x: i32, y: i32,
-                                            width: i32, height: i32) {
+    pub fn read_framebuffer_rect(&mut self,
+                                 texture_id: TextureId,
+                                 dest_x: i32,
+                                 dest_y: i32,
+                                 src_x: i32,
+                                 src_y: i32,
+                                 width: i32,
+                                 height: i32) {
         self.bind_color_texture(texture_id);
         gl::copy_tex_sub_image_2d(gl::TEXTURE_2D,
                                   0,
-                                  0,
-                                  0,
-                                  x as gl::GLint, y as gl::GLint,
-                                  width as gl::GLint, height as gl::GLint);
-    }
-
-    pub fn read_framebuffer_rect(&mut self,
-                                 texture_id: TextureId,
-                                 x: i32,
-                                 y: i32,
-                                 width: i32,
-                                 height: i32) {
-        self.read_framebuffer_rect_for_2d_texture(texture_id, x, y, width, height)
+                                  dest_x,
+                                  dest_y,
+                                  src_x as gl::GLint,
+                                  src_y as gl::GLint,
+                                  width as gl::GLint,
+                                  height as gl::GLint);
     }
 
     #[cfg(not(any(target_os = "android", target_os = "gonk")))]

--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -11,6 +11,7 @@ use std::num::Zero;
 use std::ops::Add;
 use std::path::PathBuf;
 use std::sync::Arc;
+use texture_cache::BorderType;
 use util::{self, RectVaryings};
 use webrender_traits::{FontKey, Epoch, ColorF, PipelineId};
 use webrender_traits::{ImageFormat, MixBlendMode, NativeFontHandle, DisplayItem};
@@ -377,11 +378,11 @@ pub enum RenderTargetMode {
 pub enum TextureUpdateDetails {
     Raw,
     Blit(Vec<u8>),
-    Blur(Vec<u8>, Size2D<u32>, Au, TextureImage, TextureImage),
+    Blur(Vec<u8>, Size2D<u32>, Au, TextureImage, TextureImage, BorderType),
     /// All four corners, the tessellation index, and whether inverted, respectively.
-    BorderRadius(DevicePixel, DevicePixel, DevicePixel, DevicePixel, Option<u32>, bool),
+    BorderRadius(DevicePixel, DevicePixel, DevicePixel, DevicePixel, Option<u32>, bool, BorderType),
     /// Blur radius, border radius, box rect, raster origin, and whether inverted, respectively.
-    BoxShadow(Au, Au, Rect<f32>, Point2D<f32>, bool),
+    BoxShadow(Au, Au, Rect<f32>, Point2D<f32>, bool, BorderType),
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![feature(hashmap_hasher)]
-#![feature(slice_patterns, step_by, convert, zero_one)]
+#![feature(slice_patterns, step_by, zero_one)]
 #![feature(mpsc_select)]
 
 #[macro_use]

--- a/src/texture_cache.rs
+++ b/src/texture_cache.rs
@@ -36,7 +36,7 @@ const MINIMUM_LARGE_RECT_SIZE: u32 = 32;
 
 pub type TextureCacheItemId = FreeListItemId;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum BorderType {
     NoBorder,
     SinglePixel,
@@ -631,10 +631,7 @@ impl TextureCache {
     }
 
     pub fn free_render_target(&mut self, texture_id: TextureId) {
-        let op = TextureUpdateOp::Update(0,
-                                         0,
-                                         0,
-                                         0,
+        let op = TextureUpdateOp::Update(0, 0, 0, 0,
                                          TextureUpdateDetails::Blit(Vec::new()));
         let update_op = TextureUpdate {
             id: texture_id,
@@ -820,7 +817,7 @@ impl TextureCache {
                                                height,
                                                op.image_format,
                                                TextureCacheItemKind::Standard,
-                                               BorderType::NoBorder,
+                                               BorderType::SinglePixel,
                                                TextureFilter::Linear);
 
                 assert!(allocation.kind == AllocationKind::TexturePage);        // TODO: Handle large border radii not fitting in texture cache page
@@ -837,7 +834,8 @@ impl TextureCache {
                                                     op.inner_radius_x,
                                                     op.inner_radius_y,
                                                     op.index,
-                                                    op.inverted)),
+                                                    op.inverted,
+                                                    BorderType::SinglePixel)),
                 }
             }
             &RasterItem::BoxShadow(ref op) => {
@@ -853,7 +851,7 @@ impl TextureCache {
                                                device_raster_size.height,
                                                ImageFormat::RGBA8,
                                                TextureCacheItemKind::Standard,
-                                               BorderType::NoBorder,
+                                               BorderType::SinglePixel,
                                                TextureFilter::Linear);
 
                 // TODO(pcwalton): Handle large box shadows not fitting in texture cache page.
@@ -875,7 +873,8 @@ impl TextureCache {
                                                   op.box_rect_size.1.to_f32_px())),
                             Point2D::new(op.raster_origin.0.to_f32_px(),
                                          op.raster_origin.1.to_f32_px()),
-                            op.inverted)),
+                            op.inverted,
+                            BorderType::SinglePixel)),
                 }
             }
         };
@@ -1033,14 +1032,14 @@ impl TextureCache {
                               glyph_size.width, glyph_size.height,
                               ImageFormat::RGBA8,
                               TextureCacheItemKind::Standard,
-                              BorderType::NoBorder,
+                              BorderType::SinglePixel,
                               TextureFilter::Linear);
                 self.allocate(horizontal_blur_image_id,
                               0, 0,
                               width, height,
                               ImageFormat::RGBA8,
                               TextureCacheItemKind::Alternate,
-                              BorderType::NoBorder,
+                              BorderType::SinglePixel,
                               TextureFilter::Linear);
                 let unblurred_glyph_item = self.get(unblurred_glyph_image_id);
                 let horizontal_blur_item = self.get(horizontal_blur_image_id);
@@ -1053,7 +1052,8 @@ impl TextureCache {
                                                glyph_size,
                                                blur_radius,
                                                unblurred_glyph_item.to_image(),
-                                               horizontal_blur_item.to_image()))
+                                               horizontal_blur_item.to_image(),
+                                               BorderType::SinglePixel))
             }
             (AllocationKind::Standalone, TextureInsertOp::Blit(bytes)) => {
                 TextureUpdateOp::Create(width,


### PR DESCRIPTION
Raster ops are now generated to a single render target (per format) allocated at start up.

After a raster batch is rendered, it is then blitted into the atlas, along with border edges if requested.

This is necessary since it's not possible to read from a texture bound as a render target.

This fixes several artifacts that are often noticeable with box-shadow etc.

Also fix a couple of warnings.