### PR TITLE
Use stencil buffer for clipping iframes and aabb tree nodes.

### DIFF
--- a/res/mask.fs.glsl
+++ b/res/mask.fs.glsl
@@ -1,0 +1,4 @@
+void main(void)
+{
+    SetFragColor(vColor);
+}

--- a/res/mask.vs.glsl
+++ b/res/mask.vs.glsl
@@ -1,0 +1,5 @@
+void main(void)
+{
+    vColor = aColorRectTL / 255.0;
+    gl_Position = uTransform * vec4(aPosition, 1.0);
+}

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -253,10 +253,6 @@ impl<'a> BatchBuilder<'a> {
         self.current_matrix_index += 1;
     }
 
-    pub fn clip_in_rect(&self) -> Rect<f32> {
-        self.cached_clip_in_rect.unwrap_or(MAX_RECT)
-    }
-
     // TODO(gw): This is really inefficient to call this every push/pop...
     fn update_clip_in_rect(&mut self) {
         self.cached_clip_in_rect = Some(MAX_RECT);

--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -473,10 +473,47 @@ pub struct DrawCall {
 }
 
 #[derive(Clone, Debug)]
+pub struct OutputMask {
+    pub rect: Rect<f32>,
+    pub transform: Matrix4,
+}
+
+impl OutputMask {
+    pub fn new(rect: Rect<f32>,
+               transform: Matrix4) -> OutputMask {
+        OutputMask {
+            rect: rect,
+            transform: transform,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct MaskRegion {
+    pub masks: Vec<OutputMask>,
+    pub draw_calls: Vec<DrawCall>,
+}
+
+impl MaskRegion {
+    pub fn new() -> MaskRegion {
+        MaskRegion {
+            masks: Vec::new(),
+            draw_calls: Vec::new(),
+        }
+    }
+
+    pub fn add_mask(&mut self,
+                    rect: Rect<f32>,
+                    transform: Matrix4) {
+        self.masks.push(OutputMask::new(rect, transform));
+    }
+}
+
+#[derive(Clone, Debug)]
 pub struct BatchInfo {
     pub matrix_palette: Vec<Matrix4>,
     pub offset_palette: Vec<OffsetParams>,
-    pub draw_calls: Vec<DrawCall>,
+    pub regions: Vec<MaskRegion>,
 }
 
 impl BatchInfo {
@@ -485,7 +522,7 @@ impl BatchInfo {
         BatchInfo {
             matrix_palette: matrix_palette,
             offset_palette: offset_palette,
-            draw_calls: Vec::new(),
+            regions: Vec::new(),
         }
     }
 }

--- a/src/node_compiler.rs
+++ b/src/node_compiler.rs
@@ -55,11 +55,6 @@ impl NodeCompiler for AABBTreeNode {
                         let display_item = &draw_list.items[index as usize];
 
                         let clip_rect = display_item.clip.main.intersection(&context.local_clip_rect);
-                        let clip_rect = clip_rect.and_then(|clip_rect| {
-                            let split_rect_local_space = self.split_rect
-                                                             .translate(&-context.offset_from_layer);
-                            clip_rect.intersection(&split_rect_local_space)
-                        });
 
                         if let Some(ref clip_rect) = clip_rect {
                             builder.push_clip_in_rect(clip_rect);

--- a/src/util.rs
+++ b/src/util.rs
@@ -64,6 +64,19 @@ impl MatrixHelpers for Matrix4 {
     }
 }
 
+pub trait RectHelpers {
+    fn contains_rect(&self, other: &Rect<f32>) -> bool;
+}
+
+impl RectHelpers for Rect<f32> {
+    fn contains_rect(&self, other: &Rect<f32>) -> bool {
+        self.origin.x <= other.origin.x &&
+        self.origin.y <= other.origin.y &&
+        self.max_x() >= other.max_x() &&
+        self.max_y() >= other.max_y()
+    }
+}
+
 pub fn lerp(a: f32, b: f32, t: f32) -> f32 {
     (b - a) * t + a
 }


### PR DESCRIPTION
(This allows correct clipping for these cases when transforms are involved).

This is a partial fix for #177 (the other part relies on changes to layout).